### PR TITLE
Add UI regression test suite, CI pipeline, and pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Build & Test (Unit + UI)
+    runs-on: macos-15        # Xcode 16.2 + iOS 18 simulators
+
+    steps:
+      # ── 1. Source ──────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── 2. Xcode ──────────────────────────────────────────────────────────
+      # macos-15 ships with Xcode 16.2 as the default; pin it explicitly
+      # so the build doesn't silently change when the runner image updates.
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Show Xcode & Swift versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      # ── 3. Simulator ───────────────────────────────────────────────────────
+      # Find the UDID of an available iPhone 16 (iOS 18) simulator, create it
+      # if it doesn't exist, and boot it.  The UDID is written to $GITHUB_ENV
+      # so subsequent steps can reference it via $SIMULATOR_UDID.
+      - name: Boot iOS Simulator
+        run: |
+          set -euo pipefail
+
+          UDID=$(xcrun simctl list devices available --json \
+            | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+runtimes = sorted(data['devices'].keys(), reverse=True)
+for rt in runtimes:
+    if 'iOS' not in rt:
+        continue
+    for d in data['devices'][rt]:
+        if d.get('isAvailable') and 'iPhone 16' in d.get('name', ''):
+            print(d['udid']); exit()
+# Fallback: any available iPhone
+for rt in runtimes:
+    if 'iOS' not in rt:
+        continue
+    for d in data['devices'][rt]:
+        if d.get('isAvailable') and 'iPhone' in d.get('name', ''):
+            print(d['udid']); exit()
+" 2>/dev/null || echo "")
+
+          if [ -z "$UDID" ]; then
+            echo "Creating a new iPhone 16 simulator…"
+            RUNTIME=$(xcrun simctl list runtimes available --json \
+              | python3 -c "
+import sys, json
+rts = json.load(sys.stdin)['runtimes']
+ios = [r for r in rts if 'iOS' in r.get('name','') and r.get('isAvailable')]
+ios.sort(key=lambda r: r.get('version',''), reverse=True)
+print(ios[0]['identifier'] if ios else '')
+")
+            UDID=$(xcrun simctl create "iPhone 16" "iPhone 16" "$RUNTIME")
+            echo "Created simulator $UDID"
+          fi
+
+          echo "Booting $UDID…"
+          xcrun simctl boot "$UDID" 2>/dev/null || true   # already-booted is OK
+
+          echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
+          echo "✅ Simulator ready: $UDID"
+
+      # ── 4. Tests ───────────────────────────────────────────────────────────
+      - name: Run unit + UI tests
+        run: ./scripts/run_tests.sh "$SIMULATOR_UDID"
+
+      # ── 5. Upload results ─────────────────────────────────────────────────
+      # Always upload the .xcresult bundle so failures can be inspected even
+      # when the step itself is marked as failed.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TestResults-${{ github.run_number }}
+          path: TestResults.xcresult
+          retention-days: 14

--- a/pantry/pantryApp.swift
+++ b/pantry/pantryApp.swift
@@ -27,7 +27,11 @@ struct PantryApp: App {
             RecipeCookingNote.self,
             RecipeCollection.self
         ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        // Use an in-memory store when the app is launched by the UI-test runner.
+        // This guarantees a clean, isolated data set for every test run and prevents
+        // test data from polluting the on-device store (or vice-versa).
+        let isUITesting = CommandLine.arguments.contains("-UITesting")
+        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: isUITesting)
 
         do {
             return try ModelContainer(for: schema, configurations: [modelConfiguration])

--- a/pantryUITests/pantryUITests.swift
+++ b/pantryUITests/pantryUITests.swift
@@ -2,40 +2,350 @@
 //  pantryUITests.swift
 //  pantryUITests
 //
-//  Created by Loren Schwartz on 2026-02-21.
+//  Regression test suite — run after every build.
+//
+//  Each test launches the app with the "-UITesting" flag, which switches
+//  pantryApp.swift to an in-memory SwiftData store.  This guarantees a
+//  completely clean, isolated store for every test and means tests never
+//  depend on (or corrupt) the user's real pantry data.
+//
+//  Test ID conventions:
+//    TC-01  App launches without crashing
+//    TC-02  All primary tabs are reachable
+//    TC-03  Pantry empty-state shown on a clean store
+//    TC-04  Shopping-list empty-state shown on a clean store
+//    TC-05  Adding a pantry item makes it appear in the list
+//    TC-06  Adding a shopping-list item makes it appear in the list
+//    TC-07  Pantry filter menu opens; no duplicate location entries
+//    TC-08  Checking off a shopping item shows the "checked" count
+//    TC-09  Tapping a pantry item navigates to its detail view
+//    TC-10  Swipe-to-delete removes a pantry item from the list
 //
 
 import XCTest
 
-final class pantryUITests: XCTestCase {
+final class PantryRegressionTests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    // MARK: - Suite Setup
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
+        // Stop on first failure so a broken app state doesn't cascade.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        app = XCUIApplication()
+        // Tell the app to use an in-memory SwiftData store (see pantryApp.swift).
+        app.launchArguments = ["-UITesting"]
+        app.launch()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        app = nil
     }
 
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-01  App launch
+    // ─────────────────────────────────────────────────────────────────────────
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    /// Regression: the app was crashing at launch because `initializeDefaultData()`
+    /// deleted duplicate Category/StorageLocation rows from SwiftData while `@Query`
+    /// held live in-memory references to those same objects.
+    /// Fix: store-level dedup was removed; UI-level dedup (uniqueCategories /
+    /// uniqueLocations computed properties) is used instead.
+    @MainActor
+    func test_TC01_appLaunchesWithoutCrashing() throws {
+        XCTAssertEqual(app.state, .runningForeground,
+                       "App should be running in the foreground after launch")
+        XCTAssertTrue(app.tabBars.firstMatch.waitForExistence(timeout: 5),
+                      "Main tab bar should be visible after launch")
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-02  Tab navigation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// All five main tabs must be reachable without crashing.
     @MainActor
-    func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
-        }
+    func test_TC02_allPrimaryTabsAreReachable() throws {
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 5))
+
+        // Pantry is the default/selected tab on launch.
+        XCTAssertTrue(app.navigationBars["Pantry"].waitForExistence(timeout: 5),
+                      "Pantry navigation bar should be visible on launch")
+
+        // Shopping
+        tabBar.buttons["Shopping"].tap()
+        XCTAssertTrue(app.navigationBars["Shopping List"].waitForExistence(timeout: 5),
+                      "Shopping List navigation bar should appear")
+
+        // Recipes
+        tabBar.buttons["Recipes"].tap()
+        XCTAssertTrue(app.navigationBars["Recipes"].waitForExistence(timeout: 5),
+                      "Recipes navigation bar should appear")
+
+        // Receipts
+        tabBar.buttons["Receipts"].tap()
+        XCTAssertTrue(app.navigationBars["Receipts"].waitForExistence(timeout: 5),
+                      "Receipts navigation bar should appear")
+
+        // Return to Pantry
+        tabBar.buttons["Pantry"].tap()
+        XCTAssertTrue(app.navigationBars["Pantry"].waitForExistence(timeout: 5),
+                      "Should navigate back to Pantry tab")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-03  Pantry empty state
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// A clean in-memory store should show the "No Items" ContentUnavailableView
+    /// with a prompt to add the first item.
+    @MainActor
+    func test_TC03_pantryEmptyState_shownOnCleanStore() throws {
+        XCTAssertTrue(app.staticTexts["No Items"].waitForExistence(timeout: 5),
+                      "Pantry should show 'No Items' empty state when the store is empty")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-04  Shopping-list empty state
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// A clean in-memory store should show the "Shopping List Empty" state.
+    @MainActor
+    func test_TC04_shoppingListEmptyState_shownOnCleanStore() throws {
+        app.tabBars.firstMatch.buttons["Shopping"].tap()
+        XCTAssertTrue(app.staticTexts["Shopping List Empty"].waitForExistence(timeout: 5),
+                      "Shopping should show 'Shopping List Empty' when the store is empty")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-05  Add pantry item
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Tapping +, entering a name and tapping Save should add the item to the list.
+    @MainActor
+    func test_TC05_addPantryItem_appearsInList() throws {
+        let addButton = app.navigationBars["Pantry"].buttons["Add Item"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5))
+        addButton.tap()
+
+        // The "Add Item" sheet should appear.
+        XCTAssertTrue(app.navigationBars["Add Item"].waitForExistence(timeout: 5))
+
+        // Save should be disabled until a name is entered.
+        let saveButton = app.navigationBars["Add Item"].buttons["Save"]
+        XCTAssertFalse(saveButton.isEnabled,
+                       "Save button should be disabled before a name is entered")
+
+        let nameField = app.textFields["Item Name"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 3))
+        nameField.tap()
+        nameField.typeText("Whole Milk")
+
+        XCTAssertTrue(saveButton.isEnabled,
+                      "Save button should be enabled after a name is entered")
+        saveButton.tap()
+
+        // The new item must appear in the Pantry list.
+        XCTAssertTrue(app.staticTexts["Whole Milk"].waitForExistence(timeout: 5),
+                      "Newly added item 'Whole Milk' should appear in the pantry list")
+
+        // The "No Items" empty state must be gone.
+        XCTAssertFalse(app.staticTexts["No Items"].exists,
+                       "'No Items' empty state should be hidden after adding an item")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-06  Add shopping-list item
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Tapping + on the Shopping tab, entering a name and tapping Add should
+    /// add the item to the shopping list.
+    @MainActor
+    func test_TC06_addShoppingItem_appearsInList() throws {
+        app.tabBars.firstMatch.buttons["Shopping"].tap()
+
+        let addButton = app.navigationBars["Shopping List"].buttons["Add Item"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5))
+        addButton.tap()
+
+        XCTAssertTrue(app.navigationBars["Add to List"].waitForExistence(timeout: 5))
+
+        // Add button should be disabled until a name is entered.
+        let addConfirmButton = app.navigationBars["Add to List"].buttons["Add"]
+        XCTAssertFalse(addConfirmButton.isEnabled,
+                       "Add button should be disabled before a name is entered")
+
+        let nameField = app.textFields["Item Name"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 3))
+        nameField.tap()
+        nameField.typeText("Sourdough Bread")
+
+        XCTAssertTrue(addConfirmButton.isEnabled,
+                      "Add button should be enabled after a name is entered")
+        addConfirmButton.tap()
+
+        // The item must appear in the shopping list.
+        XCTAssertTrue(app.staticTexts["Sourdough Bread"].waitForExistence(timeout: 5),
+                      "Newly added item should appear in the shopping list")
+
+        // The empty state must be gone.
+        XCTAssertFalse(app.staticTexts["Shopping List Empty"].exists,
+                       "Empty state should be hidden after an item is added")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-07  Pantry filter menu — no duplicate location entries
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Regression: a seeding race condition could insert duplicate Category /
+    /// StorageLocation rows.  The fix deduplicates at the UI layer
+    /// (uniqueLocations / uniqueCategories computed properties).
+    ///
+    /// With a fresh in-memory store, `initializeDefaultData()` runs once and
+    /// the filter menu must list each location exactly once.
+    @MainActor
+    func test_TC07_pantryFilterMenu_opensAndHasNoDuplicateLocations() throws {
+        // The options button (sort + filter menu)
+        let optionsButton = app.navigationBars["Pantry"].buttons["Options"]
+        XCTAssertTrue(optionsButton.waitForExistence(timeout: 5),
+                      "Options button should be present in the Pantry navigation bar")
+        optionsButton.tap()
+
+        // Navigate into the "Filter by Location" submenu.
+        let filterByLocation = app.buttons["Filter by Location"]
+        XCTAssertTrue(filterByLocation.waitForExistence(timeout: 3),
+                      "'Filter by Location' option should be visible in the Options menu")
+        filterByLocation.tap()
+
+        // The "All Locations" reset option must be present.
+        XCTAssertTrue(app.buttons["All Locations"].waitForExistence(timeout: 3),
+                      "'All Locations' button should be present in the location filter submenu")
+
+        // Each default location should appear exactly once.
+        // Duplicates here are the regression signal.
+        let refrigeratorButtons = app.buttons.matching(
+            NSPredicate(format: "label == 'Refrigerator'")
+        )
+        XCTAssertEqual(refrigeratorButtons.count, 1,
+                       "'Refrigerator' should appear exactly once — " +
+                       "more than one indicates a seeding/dedup regression")
+
+        let freezerButtons = app.buttons.matching(
+            NSPredicate(format: "label == 'Freezer'")
+        )
+        XCTAssertEqual(freezerButtons.count, 1,
+                       "'Freezer' should appear exactly once in the location filter")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-08  Check off a shopping item
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Tapping the checkbox of a shopping-list item should move it to the
+    /// "checked" bucket and update the summary bar count.
+    @MainActor
+    func test_TC08_checkingShoppingItem_showsCheckedCountInSummaryBar() throws {
+        app.tabBars.firstMatch.buttons["Shopping"].tap()
+
+        // Add an item.
+        app.navigationBars["Shopping List"].buttons["Add Item"].tap()
+        XCTAssertTrue(app.navigationBars["Add to List"].waitForExistence(timeout: 5))
+        let nameField = app.textFields["Item Name"]
+        nameField.tap()
+        nameField.typeText("Eggs")
+        app.navigationBars["Add to List"].buttons["Add"].tap()
+
+        // Confirm item is visible.
+        XCTAssertTrue(app.staticTexts["Eggs"].waitForExistence(timeout: 5))
+
+        // The checkbox is the first (and only free-standing) button in the item row.
+        // PantryItemRow layout: [checkboxButton] [VStack with text] [Spacer] [badge image]
+        let eggsCell = app.cells.containing(.staticText, identifier: "Eggs").firstMatch
+        XCTAssertTrue(eggsCell.waitForExistence(timeout: 3))
+        eggsCell.buttons.firstMatch.tap()
+
+        // The summary bar should now show "1 checked".
+        let checkedSummaryButton = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS '1 checked'")
+        ).firstMatch
+        XCTAssertTrue(checkedSummaryButton.waitForExistence(timeout: 5),
+                      "Summary bar should show '1 checked' after checking off an item")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-09  Pantry item detail navigation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Tapping a pantry-list row should push the ItemDetailView, and tapping
+    /// the back button should return to the list.
+    @MainActor
+    func test_TC09_tappingPantryItem_navigatesToDetailViewAndBack() throws {
+        // Add an item to tap.
+        let addButton = app.navigationBars["Pantry"].buttons["Add Item"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5))
+        addButton.tap()
+        XCTAssertTrue(app.navigationBars["Add Item"].waitForExistence(timeout: 5))
+        let nameField = app.textFields["Item Name"]
+        nameField.tap()
+        nameField.typeText("Almond Butter")
+        app.navigationBars["Add Item"].buttons["Save"].tap()
+
+        // Tap the item cell to push the detail view.
+        let cell = app.cells.containing(.staticText, identifier: "Almond Butter").firstMatch
+        XCTAssertTrue(cell.waitForExistence(timeout: 5))
+        cell.tap()
+
+        // Detail view should use the item name as the navigation bar title.
+        XCTAssertTrue(app.navigationBars["Almond Butter"].waitForExistence(timeout: 5),
+                      "Item detail view should have the item name as navigation title")
+
+        // Navigate back to the Pantry list.
+        app.navigationBars["Almond Butter"].buttons["Pantry"].tap()
+        XCTAssertTrue(app.navigationBars["Pantry"].waitForExistence(timeout: 5),
+                      "Should return to Pantry list after tapping Back")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-10  Swipe to delete a pantry item
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Swiping a pantry row left and tapping the destructive Delete action
+    /// should remove the item from the list immediately (no confirmation).
+    @MainActor
+    func test_TC10_swipeToDelete_removesPantryItemFromList() throws {
+        // Add an item to delete.
+        let addButton = app.navigationBars["Pantry"].buttons["Add Item"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5))
+        addButton.tap()
+        XCTAssertTrue(app.navigationBars["Add Item"].waitForExistence(timeout: 5))
+        let nameField = app.textFields["Item Name"]
+        nameField.tap()
+        nameField.typeText("Delete Me Item")
+        app.navigationBars["Add Item"].buttons["Save"].tap()
+
+        // Confirm the item is in the list.
+        let cell = app.cells.containing(.staticText, identifier: "Delete Me Item").firstMatch
+        XCTAssertTrue(cell.waitForExistence(timeout: 5))
+
+        // Swipe left to reveal the trailing swipe actions.
+        cell.swipeLeft()
+
+        // Tap the destructive Delete button (no confirmation dialog — direct delete).
+        let deleteButton = app.buttons["Delete"]
+        XCTAssertTrue(deleteButton.waitForExistence(timeout: 3))
+        deleteButton.tap()
+
+        // The item must no longer be in the list.
+        XCTAssertFalse(
+            app.staticTexts["Delete Me Item"].waitForExistence(timeout: 3),
+            "Item should be removed from the list after swipe-delete"
+        )
+
+        // The Pantry list should be empty again → empty state should return.
+        XCTAssertTrue(app.staticTexts["No Items"].waitForExistence(timeout: 3),
+                      "'No Items' empty state should reappear after deleting the only item")
     }
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# run_tests.sh — Build and run all Pantry tests (unit + UI)
+#
+# Usage:
+#   ./scripts/run_tests.sh              # auto-detect (or boot) a simulator
+#   ./scripts/run_tests.sh <UDID>       # use a specific simulator UDID
+#
+# When invoked as a git pre-push hook the script runs tests only if a
+# simulator is already booted.  With no booted simulator it exits 0 so
+# day-to-day pushes are never accidentally blocked.
+# GitHub Actions (ci.yml) is the authoritative CI gate.
+#
+# Output:
+#   • Raw xcodebuild output → /tmp/pantry_test_output.txt
+#   • Structured result bundle → TestResults.xcresult
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ─── 0. Resolve real script location (follows symlinks) ──────────────────────
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+    LINK_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$LINK_DIR/$SOURCE"
+done
+SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+PROJECT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+SCHEME="pantry"
+PROJECT="$PROJECT_DIR/pantry.xcodeproj"
+RESULTS="$PROJECT_DIR/TestResults.xcresult"
+LOG="/tmp/pantry_test_output.txt"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  🧪  Pantry — Test Runner"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ─── 1. Resolve simulator UDID ───────────────────────────────────────────────
+#
+# Only accept $1 as a UDID when it matches the UUID format.
+# git pre-push passes $1=remote-name, $2=remote-url — ignore those.
+
+UDID_RE='^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
+
+if [[ "${1:-}" =~ $UDID_RE ]]; then
+  # Explicit UDID from CI (GitHub Actions passes this directly).
+  SIMULATOR_UDID="$1"
+  echo "📱  Using provided simulator: $SIMULATOR_UDID"
+else
+  # ── Auto-detect a booted simulator ───────────────────────────────────────
+  # Use python3 -c so the script is a CLI arg and stdin remains free for
+  # the pipe data.  The || true prevents set -e/-o pipefail from aborting
+  # when simctl exits non-zero (e.g. when the daemon isn't running).
+  SIMULATOR_UDID=$(
+    xcrun simctl list devices booted --json 2>/dev/null \
+    | python3 -c "
+import sys, json
+try:
+    data = json.loads(sys.stdin.read())
+    for devs in data.get('devices', {}).values():
+        for d in devs:
+            if d.get('state') == 'Booted' and d.get('isAvailable', True):
+                print(d['udid']); exit()
+except Exception:
+    pass
+" 2>/dev/null
+  ) || SIMULATOR_UDID=""   # absorb any pipeline / set -e exit
+
+  if [ -z "$SIMULATOR_UDID" ]; then
+    # No booted simulator.  If we're running as a git hook (parent is git),
+    # skip gracefully so the push is never blocked by a missing simulator.
+    PARENT_CMD="$(ps -o comm= -p "$PPID" 2>/dev/null || true)"
+    if [[ "$PARENT_CMD" == *"git"* ]] || [[ "$PARENT_CMD" == *"hooks"* ]]; then
+      echo "⚠️   No booted simulator — skipping local tests."
+      echo "    GitHub Actions will run the full suite on push."
+      echo "    To run tests locally: open Simulator.app first, then push again."
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      exit 0
+    fi
+
+    # Direct invocation: try to find and boot a simulator.
+    echo "⚠️   No booted simulator. Looking for an available iPhone 16…"
+    SIMULATOR_UDID=$(
+      xcrun simctl list devices available --json 2>/dev/null \
+      | python3 -c "
+import sys, json
+try:
+    data = json.loads(sys.stdin.read())
+    runtimes = sorted(data.get('devices', {}).keys(), reverse=True)
+    for rt in runtimes:
+        if 'iOS' not in rt: continue
+        for d in data['devices'][rt]:
+            if d.get('isAvailable') and 'iPhone 16' in d.get('name', ''):
+                print(d['udid']); exit()
+    for rt in runtimes:
+        if 'iOS' not in rt: continue
+        for d in data['devices'][rt]:
+            if d.get('isAvailable') and 'iPhone' in d.get('name', ''):
+                print(d['udid']); exit()
+except Exception:
+    pass
+" 2>/dev/null
+    ) || SIMULATOR_UDID=""
+
+    if [ -z "$SIMULATOR_UDID" ]; then
+      echo "❌  No iOS simulator available."
+      echo "    Open Xcode → Window → Devices and Simulators and create one first."
+      exit 1
+    fi
+
+    echo "🔄  Booting $SIMULATOR_UDID …"
+    xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
+    sleep 5
+  fi
+
+  echo "📱  Using simulator: $SIMULATOR_UDID"
+fi
+
+# ─── 2. Run tests ─────────────────────────────────────────────────────────────
+
+echo "📂  Project : $PROJECT"
+echo "🎯  Scheme  : $SCHEME"
+echo ""
+
+rm -rf "$RESULTS"
+
+set +e
+xcodebuild test \
+  -project     "$PROJECT" \
+  -scheme      "$SCHEME"  \
+  -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+  -resultBundlePath "$RESULTS" \
+  2>&1 | tee "$LOG"
+XCODE_EXIT=${PIPESTATUS[0]}
+set -e
+
+# ─── 3. Report ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if grep -qF "** TEST SUCCEEDED **" "$LOG"; then
+  echo "  ✅  All tests passed."
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 0
+else
+  echo "  ❌  Tests failed."
+  echo ""
+  echo "  Full output : $LOG"
+  echo "  Result bundle: open $RESULTS"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit "${XCODE_EXIT:-1}"
+fi


### PR DESCRIPTION
## Summary

- **`pantryApp.swift`** — detect `-UITesting` launch arg and switch to an in-memory SwiftData store so every UI test gets a clean, isolated data set
- **`pantryUITests/pantryUITests.swift`** — replace empty stub with a 10-case regression suite (TC-01–TC-10) covering app launch, tab navigation, empty states, add/delete flows, filter-menu dedup (regression for the seeding race condition), shopping check-off, item detail navigation, and swipe-to-delete
- **`scripts/run_tests.sh`** — one-command test runner; auto-detects or boots an iOS simulator; uses `python3 -c` so stdin stays free for simctl pipe data; installed as `.git/hooks/pre-push` (skips gracefully when no simulator is booted)
- **`.github/workflows/ci.yml`** — GitHub Actions job on `macos-15` / Xcode 16.2 that boots an iPhone 16 simulator, runs the full test suite on every push and PR to `main`, and uploads `TestResults.xcresult` as a build artifact

## Test plan

- [ ] Merge triggers GitHub Actions CI run — confirm ✅ or investigate failures
- [ ] On a machine with a booted simulator: `./scripts/run_tests.sh` runs and reports pass/fail
- [ ] Push a commit with a simulator booted — pre-push hook runs tests before the push goes through
- [ ] Push a commit with no simulator open — hook prints warning and exits 0 (push succeeds, CI runs on GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)