### PR TITLE
Add LLM chat assistant interface with full pantry tool use

### DIFF
--- a/pantry/ServicesLLMService.swift
+++ b/pantry/ServicesLLMService.swift
@@ -1,0 +1,891 @@
+//
+//  LLMService.swift
+//  pantry
+//
+//  LLM-powered assistant that can read and write pantry, recipe, and
+//  shopping-list data via Claude tool use. Network calls are made with
+//  URLSession; no third-party packages are required.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - Chat Message
+
+struct ChatMessage: Identifiable, Equatable {
+    let id: UUID
+    var role: Role
+    var content: String
+    var isLoading: Bool
+    var toolActivity: String?
+
+    enum Role: Equatable {
+        case user, assistant
+    }
+
+    init(
+        id: UUID = UUID(),
+        role: Role,
+        content: String,
+        isLoading: Bool = false,
+        toolActivity: String? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.isLoading = isLoading
+        self.toolActivity = toolActivity
+    }
+}
+
+// MARK: - Tool Formatter
+// Pure, static functions — no side effects, fully testable without SwiftData.
+
+enum LLMToolFormatter {
+
+    static func pantryItemsJSON(_ items: [PantryItem]) -> String {
+        guard !items.isEmpty else { return "[]" }
+        let dicts: [[String: Any]] = items.map { item in
+            var d: [String: Any] = [
+                "name": item.name,
+                "quantity": item.quantity,
+                "unit": item.unit,
+                "is_expired": item.isExpired,
+                "is_expiring_soon": item.isExpiringSoon,
+                "low_stock": item.isLowStock
+            ]
+            if let brand = item.brand { d["brand"] = brand }
+            if let price = item.price { d["price"] = price }
+            if let days = item.daysUntilExpiration { d["days_until_expiration"] = days }
+            if let cat = item.category { d["category"] = cat.name }
+            if let loc = item.location { d["location"] = loc.name }
+            if let notes = item.notes { d["notes"] = notes }
+            return d
+        }
+        return serialize(dicts)
+    }
+
+    static func recipesJSON(_ recipes: [Recipe]) -> String {
+        guard !recipes.isEmpty else { return "[]" }
+        let dicts: [[String: Any]] = recipes.map { recipe in
+            var d: [String: Any] = [
+                "name": recipe.name,
+                "prep_time_minutes": recipe.prepTime,
+                "cook_time_minutes": recipe.cookTime,
+                "total_time_minutes": recipe.totalTime,
+                "servings": recipe.servings,
+                "difficulty": recipe.difficulty.rawValue,
+                "ingredient_count": recipe.ingredientCount,
+                "is_favorite": recipe.isFavorite
+            ]
+            if let desc = recipe.recipeDescription { d["description"] = desc }
+            if let rating = recipe.rating { d["rating"] = rating }
+            return d
+        }
+        return serialize(dicts)
+    }
+
+    static func recipeDetailJSON(_ recipe: Recipe) -> String {
+        var d: [String: Any] = [
+            "name": recipe.name,
+            "prep_time_minutes": recipe.prepTime,
+            "cook_time_minutes": recipe.cookTime,
+            "total_time_minutes": recipe.totalTime,
+            "servings": recipe.servings,
+            "difficulty": recipe.difficulty.rawValue,
+            "is_favorite": recipe.isFavorite,
+            "times_cooked": recipe.timesCookedCount
+        ]
+        if let desc = recipe.recipeDescription { d["description"] = desc }
+        if let rating = recipe.rating { d["rating"] = rating }
+        if let notes = recipe.notes { d["notes"] = notes }
+
+        let ingredients: [[String: Any]] = (recipe.ingredients ?? [])
+            .sorted { $0.sortOrder < $1.sortOrder }
+            .map { ing in
+                var id: [String: Any] = [
+                    "name": ing.name,
+                    "quantity": ing.quantity,
+                    "unit": ing.unit,
+                    "is_optional": ing.isOptional
+                ]
+                if let n = ing.notes { id["notes"] = n }
+                return id
+            }
+        d["ingredients"] = ingredients
+
+        let instructions: [[String: Any]] = (recipe.instructions ?? [])
+            .sorted { $0.stepNumber < $1.stepNumber }
+            .map { step in
+                var sd: [String: Any] = [
+                    "step": step.stepNumber,
+                    "instruction": step.instruction
+                ]
+                if let t = step.timerDuration { sd["timer_minutes"] = t }
+                return sd
+            }
+        d["instructions"] = instructions
+
+        return serialize(d)
+    }
+
+    static func shoppingItemsJSON(_ items: [ShoppingListItem]) -> String {
+        guard !items.isEmpty else { return "[]" }
+        let dicts: [[String: Any]] = items.map { item in
+            var d: [String: Any] = [
+                "name": item.name,
+                "quantity": item.quantity,
+                "unit": item.unit,
+                "is_checked": item.isChecked,
+                "priority": item.priority
+            ]
+            if let notes = item.notes { d["notes"] = notes }
+            if let price = item.estimatedPrice { d["estimated_price"] = price }
+            if let cat = item.category { d["category"] = cat.name }
+            return d
+        }
+        return serialize(dicts)
+    }
+
+    static func expiringItemsJSON(_ items: [PantryItem]) -> String {
+        let expiring = items.filter { $0.isExpiringSoon || $0.isExpired }
+        guard !expiring.isEmpty else { return "[]" }
+        let dicts: [[String: Any]] = expiring.map { item in
+            var d: [String: Any] = [
+                "name": item.name,
+                "quantity": item.quantity,
+                "unit": item.unit,
+                "is_expired": item.isExpired
+            ]
+            if let days = item.daysUntilExpiration { d["days_until_expiration"] = days }
+            if let cat = item.category { d["category"] = cat.name }
+            return d
+        }
+        return serialize(dicts)
+    }
+
+    // MARK: - Private helpers
+
+    private static func serialize(_ object: Any) -> String {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys]
+        ), let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+}
+
+// MARK: - LLM Error
+
+enum LLMError: LocalizedError {
+    case missingAPIKey
+    case invalidAPIKey
+    case rateLimited
+    case serverError(Int)
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "No API key configured. Please add your Anthropic API key in Assistant settings."
+        case .invalidAPIKey:
+            return "Invalid API key. Please check your Anthropic API key."
+        case .rateLimited:
+            return "Rate limited. Please wait a moment and try again."
+        case .serverError(let code):
+            return "Server error (\(code)). Please try again later."
+        case .invalidResponse:
+            return "Received an unexpected response. Please try again."
+        }
+    }
+}
+
+// MARK: - LLM Service
+
+@Observable
+@MainActor
+final class LLMService {
+
+    // MARK: Public state
+
+    var chatMessages: [ChatMessage] = []
+    var isLoading = false
+
+    var apiKey: String {
+        get { UserDefaults.standard.string(forKey: "anthropic_api_key") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "anthropic_api_key") }
+    }
+
+    var hasAPIKey: Bool { !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    // MARK: Private state
+
+    private var conversationHistory: [[String: Any]] = []
+    private let modelID = "claude-opus-4-6"
+    private let maxTokens = 4096
+
+    // MARK: - Public API
+
+    func clearConversation() {
+        chatMessages = []
+        conversationHistory = []
+    }
+
+    /// Send a user message and run the full tool-use agentic loop until
+    /// Claude produces a final text response.
+    func sendMessage(_ userMessage: String, context: ModelContext) async {
+        let trimmed = userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        chatMessages.append(ChatMessage(role: .user, content: trimmed))
+        conversationHistory.append(["role": "user", "content": trimmed])
+
+        isLoading = true
+        let loadingIndex = chatMessages.count
+        chatMessages.append(ChatMessage(role: .assistant, content: "", isLoading: true))
+
+        do {
+            try await runAgentLoop(context: context, loadingIndex: loadingIndex)
+        } catch {
+            let message = (error as? LLMError)?.errorDescription
+                ?? "Error: \(error.localizedDescription)"
+            chatMessages[loadingIndex] = ChatMessage(role: .assistant, content: message)
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Agent Loop
+
+    private func runAgentLoop(context: ModelContext, loadingIndex: Int) async throws {
+        var continueLoop = true
+        while continueLoop {
+            let response = try await callAnthropicAPI(messages: conversationHistory)
+
+            guard
+                let content = response["content"] as? [[String: Any]],
+                let stopReason = response["stop_reason"] as? String
+            else { throw LLMError.invalidResponse }
+
+            conversationHistory.append(["role": "assistant", "content": content])
+
+            switch stopReason {
+            case "end_turn":
+                let text = content
+                    .filter { ($0["type"] as? String) == "text" }
+                    .compactMap { $0["text"] as? String }
+                    .joined()
+                chatMessages[loadingIndex] = ChatMessage(role: .assistant, content: text)
+                continueLoop = false
+
+            case "tool_use":
+                let toolUseBlocks = content.filter { ($0["type"] as? String) == "tool_use" }
+                var toolResults: [[String: Any]] = []
+
+                for block in toolUseBlocks {
+                    guard
+                        let toolID = block["id"] as? String,
+                        let toolName = block["name"] as? String,
+                        let toolInput = block["input"] as? [String: Any]
+                    else { continue }
+
+                    chatMessages[loadingIndex] = ChatMessage(
+                        role: .assistant,
+                        content: "",
+                        isLoading: true,
+                        toolActivity: activityLabel(for: toolName)
+                    )
+
+                    let result = executeTool(toolName, input: toolInput, context: context)
+                    toolResults.append([
+                        "type": "tool_result",
+                        "tool_use_id": toolID,
+                        "content": result
+                    ])
+                }
+
+                conversationHistory.append(["role": "user", "content": toolResults])
+
+            default:
+                continueLoop = false
+            }
+        }
+    }
+
+    // MARK: - Tool Execution
+
+    private func executeTool(
+        _ name: String,
+        input: [String: Any],
+        context: ModelContext
+    ) -> String {
+        switch name {
+        case "get_pantry_items":
+            return LLMToolFormatter.pantryItemsJSON(fetchPantryItems(context: context))
+
+        case "add_pantry_item":
+            return addPantryItem(input: input, context: context)
+
+        case "update_pantry_item":
+            return updatePantryItem(input: input, context: context)
+
+        case "remove_pantry_item":
+            return removePantryItem(input: input, context: context)
+
+        case "get_recipes":
+            return LLMToolFormatter.recipesJSON(fetchRecipes(context: context))
+
+        case "get_recipe_details":
+            guard let recipeName = input["name"] as? String else {
+                return "Error: recipe name is required"
+            }
+            let recipes = fetchRecipes(context: context)
+            guard let recipe = recipes.first(where: {
+                $0.name.localizedCaseInsensitiveContains(recipeName)
+            }) else {
+                return "Recipe not found: \(recipeName)"
+            }
+            return LLMToolFormatter.recipeDetailJSON(recipe)
+
+        case "create_recipe":
+            return createRecipe(input: input, context: context)
+
+        case "get_shopping_list":
+            return LLMToolFormatter.shoppingItemsJSON(fetchShoppingItems(context: context))
+
+        case "add_to_shopping_list":
+            return addToShoppingList(input: input, context: context)
+
+        case "check_shopping_item":
+            return checkShoppingItem(input: input, context: context)
+
+        case "clear_checked_shopping_items":
+            return clearCheckedItems(context: context)
+
+        case "get_expiring_items":
+            return LLMToolFormatter.expiringItemsJSON(fetchPantryItems(context: context))
+
+        case "suggest_recipes":
+            let pantry = fetchPantryItems(context: context)
+            let recipes = fetchRecipes(context: context)
+            return suggestRecipes(pantry: pantry, recipes: recipes)
+
+        default:
+            return "Unknown tool: \(name)"
+        }
+    }
+
+    // MARK: - SwiftData Fetch Helpers
+
+    private func fetchPantryItems(context: ModelContext) -> [PantryItem] {
+        let descriptor = FetchDescriptor<PantryItem>(
+            predicate: #Predicate { !$0.isArchived },
+            sortBy: [SortDescriptor(\.name)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func fetchRecipes(context: ModelContext) -> [Recipe] {
+        let descriptor = FetchDescriptor<Recipe>(sortBy: [SortDescriptor(\.name)])
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func fetchShoppingItems(context: ModelContext) -> [ShoppingListItem] {
+        let descriptor = FetchDescriptor<ShoppingListItem>(
+            sortBy: [SortDescriptor(\.addedDate)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    // MARK: - Individual Tool Implementations
+
+    private func addPantryItem(input: [String: Any], context: ModelContext) -> String {
+        guard let name = input["name"] as? String, !name.isEmpty else {
+            return "Error: item name is required"
+        }
+        let quantity = doubleValue(from: input["quantity"]) ?? 1.0
+        let unit = input["unit"] as? String ?? "item"
+        let brand = input["brand"] as? String
+        let notes = input["notes"] as? String
+        let expirationDate = parseDate(input["expiration_date"] as? String)
+
+        let item = PantryItem(
+            name: name,
+            quantity: quantity,
+            unit: unit,
+            brand: brand,
+            expirationDate: expirationDate,
+            notes: notes
+        )
+        context.insert(item)
+
+        var confirmation = "Added \(quantity) \(unit) of \(name) to your pantry"
+        if let brand { confirmation += " (\(brand))" }
+        if let expirationDate {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            confirmation += ", expires \(formatter.string(from: expirationDate))"
+        }
+        return confirmation
+    }
+
+    private func updatePantryItem(input: [String: Any], context: ModelContext) -> String {
+        guard let name = input["name"] as? String else {
+            return "Error: item name is required"
+        }
+        let items = fetchPantryItems(context: context)
+        guard let item = items.first(where: {
+            $0.name.localizedCaseInsensitiveContains(name)
+        }) else {
+            return "Could not find '\(name)' in your pantry"
+        }
+
+        if let qty = doubleValue(from: input["quantity"]) { item.quantity = qty }
+        if let unit = input["unit"] as? String { item.unit = unit }
+        if let brand = input["brand"] as? String { item.brand = brand }
+        if let notes = input["notes"] as? String { item.notes = notes }
+        if let date = parseDate(input["expiration_date"] as? String) {
+            item.expirationDate = date
+        }
+        item.modifiedDate = Date()
+
+        return "Updated '\(item.name)' in your pantry"
+    }
+
+    private func removePantryItem(input: [String: Any], context: ModelContext) -> String {
+        guard let name = input["name"] as? String else {
+            return "Error: item name is required"
+        }
+        let items = fetchPantryItems(context: context)
+        guard let item = items.first(where: {
+            $0.name.localizedCaseInsensitiveContains(name)
+        }) else {
+            return "Could not find '\(name)' in your pantry"
+        }
+        let itemName = item.name
+        context.delete(item)
+        return "Removed '\(itemName)' from your pantry"
+    }
+
+    private func createRecipe(input: [String: Any], context: ModelContext) -> String {
+        guard let name = input["name"] as? String, !name.isEmpty else {
+            return "Error: recipe name is required"
+        }
+
+        let difficulty: RecipeDifficulty
+        switch (input["difficulty"] as? String)?.lowercased() {
+        case "easy": difficulty = .easy
+        case "hard": difficulty = .hard
+        default: difficulty = .medium
+        }
+
+        let recipe = Recipe(
+            name: name,
+            description: input["description"] as? String,
+            prepTime: input["prep_time"] as? Int ?? 0,
+            cookTime: input["cook_time"] as? Int ?? 0,
+            servings: input["servings"] as? Int ?? 4,
+            difficulty: difficulty,
+            notes: input["notes"] as? String
+        )
+        context.insert(recipe)
+
+        // Ingredients
+        var ingredientCount = 0
+        if let ingData = input["ingredients"] as? [[String: Any]] {
+            ingredientCount = ingData.count
+            for (index, data) in ingData.enumerated() {
+                let ing = RecipeIngredient(
+                    name: data["name"] as? String ?? "Ingredient",
+                    quantity: doubleValue(from: data["quantity"]) ?? 1.0,
+                    unit: data["unit"] as? String ?? "item",
+                    notes: data["notes"] as? String,
+                    sortOrder: index
+                )
+                ing.recipe = recipe
+                context.insert(ing)
+            }
+        }
+
+        // Instructions (accept either [String] or [[String: Any]])
+        var stepCount = 0
+        if let steps = input["instructions"] as? [String] {
+            stepCount = steps.count
+            for (index, text) in steps.enumerated() {
+                let instruction = RecipeInstruction(stepNumber: index + 1, instruction: text)
+                instruction.recipe = recipe
+                context.insert(instruction)
+            }
+        } else if let steps = input["instructions"] as? [[String: Any]] {
+            stepCount = steps.count
+            for (index, data) in steps.enumerated() {
+                let text = data["instruction"] as? String ?? data["text"] as? String ?? ""
+                let instruction = RecipeInstruction(
+                    stepNumber: index + 1,
+                    instruction: text,
+                    timerDuration: data["timer_minutes"] as? Int
+                )
+                instruction.recipe = recipe
+                context.insert(instruction)
+            }
+        }
+
+        return "Created recipe '\(name)' with \(ingredientCount) ingredient(s) and \(stepCount) step(s)"
+    }
+
+    private func addToShoppingList(input: [String: Any], context: ModelContext) -> String {
+        guard let name = input["name"] as? String, !name.isEmpty else {
+            return "Error: item name is required"
+        }
+        let quantity = doubleValue(from: input["quantity"]) ?? 1.0
+        let unit = input["unit"] as? String ?? "item"
+        let item = ShoppingListItem(
+            name: name,
+            quantity: quantity,
+            unit: unit,
+            notes: input["notes"] as? String,
+            priority: input["priority"] as? Int ?? 1
+        )
+        context.insert(item)
+        return "Added \(quantity) \(unit) of \(name) to your shopping list"
+    }
+
+    private func checkShoppingItem(input: [String: Any], context: ModelContext) -> String {
+        guard let name = input["name"] as? String else {
+            return "Error: item name is required"
+        }
+        let checked = input["checked"] as? Bool ?? true
+        let items = fetchShoppingItems(context: context)
+        guard let item = items.first(where: {
+            $0.name.localizedCaseInsensitiveContains(name)
+        }) else {
+            return "Could not find '\(name)' on the shopping list"
+        }
+        item.isChecked = checked
+        if checked { item.checkedDate = Date() }
+        return "\(checked ? "Checked off" : "Unchecked") '\(item.name)'"
+    }
+
+    private func clearCheckedItems(context: ModelContext) -> String {
+        let items = fetchShoppingItems(context: context)
+        let checked = items.filter { $0.isChecked }
+        let count = checked.count
+        for item in checked { context.delete(item) }
+        return "Removed \(count) checked item(s) from the shopping list"
+    }
+
+    private func suggestRecipes(pantry: [PantryItem], recipes: [Recipe]) -> String {
+        guard !recipes.isEmpty else { return "No recipes saved yet." }
+        let results = RecipePantryService.makeableRecipes(recipes: recipes, pantryItems: pantry)
+        let top = results
+            .sorted { $0.matchPercentage > $1.matchPercentage }
+            .prefix(5)
+            .map { item -> [String: Any] in
+                [
+                    "name": item.recipe.name,
+                    "match_percentage": Int(item.matchPercentage),
+                    "missing_ingredients": item.missingIngredients.map { $0.name },
+                    "total_time_minutes": item.recipe.totalTime,
+                    "difficulty": item.recipe.difficulty.rawValue
+                ]
+            }
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: Array(top),
+            options: [.prettyPrinted, .sortedKeys]
+        ), let string = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return string
+    }
+
+    // MARK: - Utility Helpers
+
+    private func doubleValue(from value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        return nil
+    }
+
+    private func parseDate(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: string)
+    }
+
+    private func activityLabel(for toolName: String) -> String {
+        switch toolName {
+        case "get_pantry_items":           return "Checking your pantry…"
+        case "add_pantry_item":            return "Adding item to pantry…"
+        case "update_pantry_item":         return "Updating pantry item…"
+        case "remove_pantry_item":         return "Removing item from pantry…"
+        case "get_recipes":               return "Browsing your recipes…"
+        case "get_recipe_details":         return "Looking up recipe…"
+        case "create_recipe":             return "Creating recipe…"
+        case "get_shopping_list":          return "Checking shopping list…"
+        case "add_to_shopping_list":       return "Adding to shopping list…"
+        case "check_shopping_item":        return "Updating shopping list…"
+        case "clear_checked_shopping_items": return "Clearing checked items…"
+        case "get_expiring_items":         return "Checking expiring items…"
+        case "suggest_recipes":            return "Finding recipe suggestions…"
+        default:                           return "Working…"
+        }
+    }
+
+    // MARK: - API Call
+
+    private func callAnthropicAPI(messages: [[String: Any]]) async throws -> [String: Any] {
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { throw LLMError.missingAPIKey }
+
+        let url = URL(string: "https://api.anthropic.com/v1/messages")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(key, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.timeoutInterval = 90
+
+        let body: [String: Any] = [
+            "model": modelID,
+            "max_tokens": maxTokens,
+            "system": systemPrompt,
+            "tools": toolDefinitions,
+            "messages": messages
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let http = response as? HTTPURLResponse {
+            switch http.statusCode {
+            case 401: throw LLMError.invalidAPIKey
+            case 429: throw LLMError.rateLimited
+            case 500...: throw LLMError.serverError(http.statusCode)
+            default: break
+            }
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw LLMError.invalidResponse
+        }
+
+        // Surface API-level error messages
+        if let error = json["error"] as? [String: Any],
+           let message = error["message"] as? String {
+            throw NSError(
+                domain: "AnthropicAPI",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+
+        return json
+    }
+
+    // MARK: - System Prompt
+
+    private var systemPrompt: String {
+        let date = DateFormatter.localizedString(from: Date(), dateStyle: .long, timeStyle: .none)
+        return """
+        You are a helpful kitchen and pantry assistant integrated into the Pantry iOS app. \
+        You help users manage their grocery inventory, recipes, and shopping lists.
+
+        You have tools that let you:
+        - View, add, update, and remove pantry items
+        - Browse recipes and get full details (ingredients + instructions)
+        - Create new recipes from scratch
+        - Manage the shopping list (view, add, check off, clear)
+        - See which items are expiring soon
+        - Suggest recipes based on what is currently in the pantry
+
+        Guidelines:
+        - Act on clear requests immediately without asking for unnecessary confirmation.
+        - When adding items, make sensible defaults for missing fields (e.g., quantity=1, unit="item").
+        - When suggesting dinner ideas, call suggest_recipes first to see what is available, \
+          then be creative and helpful in your recommendations.
+        - For recipe creation, include enough detail so the user can actually cook the dish.
+        - Be conversational and friendly, like a knowledgeable sous-chef.
+        - Today's date is \(date).
+        """
+    }
+
+    // MARK: - Tool Definitions
+
+    private var toolDefinitions: [[String: Any]] {
+        [
+            [
+                "name": "get_pantry_items",
+                "description": "Get all items currently in the pantry inventory, including quantity, unit, expiration status, and category.",
+                "input_schema": emptySchema()
+            ],
+            [
+                "name": "add_pantry_item",
+                "description": "Add a new item to the pantry inventory.",
+                "input_schema": schema(
+                    properties: [
+                        "name":            strProp("Name of the item to add"),
+                        "quantity":        numProp("Amount (e.g. 2, 0.5)"),
+                        "unit":            strProp("Unit of measurement (count, lb, kg, gallon, can, box, bag, etc.)"),
+                        "brand":           strProp("Brand name, if known"),
+                        "expiration_date": strProp("Expiration date in YYYY-MM-DD format"),
+                        "notes":           strProp("Any additional notes")
+                    ],
+                    required: ["name"]
+                )
+            ],
+            [
+                "name": "update_pantry_item",
+                "description": "Update an existing pantry item's quantity, unit, brand, expiration date, or notes. Uses fuzzy name matching.",
+                "input_schema": schema(
+                    properties: [
+                        "name":            strProp("Name of the item to update (fuzzy match)"),
+                        "quantity":        numProp("New quantity"),
+                        "unit":            strProp("New unit"),
+                        "brand":           strProp("New brand"),
+                        "expiration_date": strProp("New expiration date in YYYY-MM-DD format"),
+                        "notes":           strProp("New notes")
+                    ],
+                    required: ["name"]
+                )
+            ],
+            [
+                "name": "remove_pantry_item",
+                "description": "Remove an item from the pantry inventory. Uses fuzzy name matching.",
+                "input_schema": schema(
+                    properties: ["name": strProp("Name of the item to remove")],
+                    required: ["name"]
+                )
+            ],
+            [
+                "name": "get_recipes",
+                "description": "Get a list of all saved recipes with basic info (name, times, difficulty, ingredient count, favorite status).",
+                "input_schema": emptySchema()
+            ],
+            [
+                "name": "get_recipe_details",
+                "description": "Get full details of a specific recipe including all ingredients with quantities and step-by-step instructions.",
+                "input_schema": schema(
+                    properties: ["name": strProp("Name of the recipe to look up (fuzzy match)")],
+                    required: ["name"]
+                )
+            ],
+            [
+                "name": "create_recipe",
+                "description": "Create and save a new recipe with ingredients and instructions.",
+                "input_schema": [
+                    "type": "object",
+                    "properties": [
+                        "name":        strProp("Recipe name"),
+                        "description": strProp("Brief description of the dish"),
+                        "prep_time":   intProp("Prep time in minutes"),
+                        "cook_time":   intProp("Cook time in minutes"),
+                        "servings":    intProp("Number of servings"),
+                        "difficulty": [
+                            "type": "string",
+                            "enum": ["easy", "medium", "hard"],
+                            "description": "Difficulty level"
+                        ] as [String: Any],
+                        "ingredients": [
+                            "type": "array",
+                            "description": "List of ingredients",
+                            "items": [
+                                "type": "object",
+                                "properties": [
+                                    "name":     strProp("Ingredient name"),
+                                    "quantity": numProp("Amount"),
+                                    "unit":     strProp("Unit (g, cup, tbsp, count, etc.)"),
+                                    "notes":    strProp("Preparation note, e.g. 'finely chopped'")
+                                ] as [String: Any],
+                                "required": ["name", "quantity", "unit"]
+                            ] as [String: Any]
+                        ] as [String: Any],
+                        "instructions": [
+                            "type": "array",
+                            "description": "Step-by-step instructions as plain strings",
+                            "items": ["type": "string"] as [String: Any]
+                        ] as [String: Any],
+                        "notes": strProp("Personal notes or cooking tips")
+                    ] as [String: Any],
+                    "required": ["name", "ingredients", "instructions"]
+                ] as [String: Any]
+            ],
+            [
+                "name": "get_shopping_list",
+                "description": "Get all items on the shopping list with quantity, unit, checked status, and priority.",
+                "input_schema": emptySchema()
+            ],
+            [
+                "name": "add_to_shopping_list",
+                "description": "Add an item to the shopping list.",
+                "input_schema": schema(
+                    properties: [
+                        "name":     strProp("Item name"),
+                        "quantity": numProp("Amount needed"),
+                        "unit":     strProp("Unit"),
+                        "notes":    strProp("Brand preference or other notes"),
+                        "priority": [
+                            "type": "integer",
+                            "description": "Priority level: 0=low, 1=medium, 2=high",
+                            "enum": [0, 1, 2]
+                        ] as [String: Any]
+                    ],
+                    required: ["name"]
+                )
+            ],
+            [
+                "name": "check_shopping_item",
+                "description": "Mark a shopping list item as checked (bought) or unchecked. Uses fuzzy name matching.",
+                "input_schema": schema(
+                    properties: [
+                        "name":    strProp("Item name (fuzzy match)"),
+                        "checked": ["type": "boolean", "description": "True to check off, false to uncheck"] as [String: Any]
+                    ],
+                    required: ["name"]
+                )
+            ],
+            [
+                "name": "clear_checked_shopping_items",
+                "description": "Remove all checked (purchased) items from the shopping list.",
+                "input_schema": emptySchema()
+            ],
+            [
+                "name": "get_expiring_items",
+                "description": "Get pantry items that are expiring within 7 days or already expired.",
+                "input_schema": emptySchema()
+            ],
+            [
+                "name": "suggest_recipes",
+                "description": "Suggest recipes based on what is currently in the pantry, ranked by ingredient availability percentage.",
+                "input_schema": emptySchema()
+            ]
+        ]
+    }
+
+    // MARK: - Schema Builder Helpers
+
+    private func emptySchema() -> [String: Any] {
+        ["type": "object", "properties": [:] as [String: Any], "required": [] as [String]]
+    }
+
+    private func schema(
+        properties: [String: [String: Any]],
+        required: [String]
+    ) -> [String: Any] {
+        ["type": "object", "properties": properties as [String: Any], "required": required]
+    }
+
+    private func strProp(_ description: String) -> [String: Any] {
+        ["type": "string", "description": description]
+    }
+
+    private func numProp(_ description: String) -> [String: Any] {
+        ["type": "number", "description": description]
+    }
+
+    private func intProp(_ description: String) -> [String: Any] {
+        ["type": "integer", "description": description]
+    }
+}

--- a/pantry/ViewsChatChatView.swift
+++ b/pantry/ViewsChatChatView.swift
@@ -1,0 +1,382 @@
+//
+//  ChatView.swift
+//  pantry
+//
+//  The main LLM assistant chat interface. Users interact with an AI that can
+//  read and write pantry, recipe, and shopping-list data via tool use.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: - Chat View
+
+struct ChatView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \PantryItem.name) private var pantryItems: [PantryItem]
+    @Query(sort: \Recipe.name) private var recipes: [Recipe]
+    @Query(sort: \ShoppingListItem.addedDate) private var shoppingItems: [ShoppingListItem]
+
+    @State private var service = LLMService()
+    @State private var inputText = ""
+    @State private var showAPIKeySheet = false
+    @FocusState private var isInputFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                if service.hasAPIKey {
+                    chatInterface
+                } else {
+                    APIKeySetupView(service: service)
+                }
+            }
+            .navigationTitle("Pantry Assistant")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarItems }
+            .sheet(isPresented: $showAPIKeySheet) {
+                APIKeySetupView(service: service)
+                    .presentationDetents([.medium])
+            }
+        }
+    }
+
+    // MARK: - Chat Interface
+
+    @ViewBuilder
+    private var chatInterface: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    if service.chatMessages.isEmpty {
+                        WelcomeMessageView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.top, 48)
+                    }
+                    ForEach(service.chatMessages) { message in
+                        ChatBubbleView(message: message)
+                            .id(message.id)
+                    }
+                    Color.clear
+                        .frame(height: 8)
+                        .id("bottom")
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+            }
+            .onChange(of: service.chatMessages.count) {
+                withAnimation(.easeOut(duration: 0.25)) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+            }
+            .onChange(of: service.chatMessages.last?.content) {
+                withAnimation(.easeOut(duration: 0.15)) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+            }
+        }
+
+        Divider()
+
+        ChatInputBar(
+            text: $inputText,
+            isLoading: service.isLoading,
+            isFocused: _isInputFocused,
+            onSend: sendMessage
+        )
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarItems: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarTrailing) {
+            if service.hasAPIKey {
+                Menu {
+                    Button {
+                        showAPIKeySheet = true
+                    } label: {
+                        Label("API Key Settings", systemImage: "key")
+                    }
+                    Divider()
+                    Button(role: .destructive) {
+                        service.clearConversation()
+                    } label: {
+                        Label("Clear Chat", systemImage: "trash")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+    }
+
+    // MARK: - Send Message
+
+    private func sendMessage() {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        inputText = ""
+        isInputFocused = false
+        Task {
+            await service.sendMessage(text, context: modelContext)
+        }
+    }
+}
+
+// MARK: - Chat Bubble
+
+struct ChatBubbleView: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            if message.role == .user { Spacer(minLength: 48) }
+
+            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 4) {
+                if message.isLoading {
+                    LoadingBubbleView(activity: message.toolActivity)
+                } else {
+                    Text(message.content)
+                        .textSelection(.enabled)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(bubbleColor)
+                        .foregroundStyle(textColor)
+                        .clipShape(bubbleShape)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
+
+            if message.role == .assistant { Spacer(minLength: 48) }
+        }
+    }
+
+    private var bubbleColor: Color {
+        message.role == .user ? Color.accentColor : Color(.secondarySystemBackground)
+    }
+
+    private var textColor: Color {
+        message.role == .user ? .white : .primary
+    }
+
+    private var bubbleShape: some Shape {
+        RoundedRectangle(cornerRadius: 18)
+    }
+}
+
+// MARK: - Loading Bubble
+
+struct LoadingBubbleView: View {
+    let activity: String?
+
+    @State private var dotPhase = 0
+
+    var body: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 4) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .frame(width: 7, height: 7)
+                        .scaleEffect(dotPhase == index ? 1.2 : 0.8)
+                        .opacity(dotPhase == index ? 1.0 : 0.4)
+                        .animation(
+                            .easeInOut(duration: 0.4).repeatForever().delay(Double(index) * 0.15),
+                            value: dotPhase
+                        )
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+
+            if let activity {
+                Text(activity)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .transition(.opacity)
+            }
+        }
+        .onAppear {
+            dotPhase = 1
+        }
+    }
+}
+
+// MARK: - Input Bar
+
+struct ChatInputBar: View {
+    @Binding var text: String
+    let isLoading: Bool
+    @FocusState var isFocused: Bool
+    let onSend: () -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            TextField("Message", text: $text, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...6)
+                .focused($isFocused)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .onSubmit {
+                    if !isLoading { onSend() }
+                }
+
+            Button(action: onSend) {
+                Image(systemName: isLoading ? "stop.circle.fill" : "arrow.up.circle.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(canSend ? Color.accentColor : Color.secondary)
+            }
+            .disabled(!canSend)
+            .animation(.easeInOut(duration: 0.15), value: canSend)
+        }
+    }
+
+    private var canSend: Bool {
+        !isLoading && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+// MARK: - Welcome Message
+
+struct WelcomeMessageView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "fork.knife.circle.fill")
+                .font(.system(size: 60))
+                .foregroundStyle(.tint)
+
+            VStack(spacing: 8) {
+                Text("Pantry Assistant")
+                    .font(.title2.bold())
+                Text("I can help you manage your pantry, find recipes, and build shopping lists.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            VStack(spacing: 10) {
+                SuggestionChip(text: "What can I make for dinner tonight?")
+                SuggestionChip(text: "Add 2 lbs of chicken to my pantry")
+                SuggestionChip(text: "What's expiring soon?")
+                SuggestionChip(text: "Create a recipe for pasta carbonara")
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Suggestion Chip
+
+struct SuggestionChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.subheadline)
+            .foregroundStyle(.tint)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(Color.accentColor.opacity(0.1))
+            .clipShape(Capsule())
+    }
+}
+
+// MARK: - API Key Setup View
+
+struct APIKeySetupView: View {
+    @Bindable var service: LLMService
+    @State private var keyInput = ""
+    @State private var isSecure = true
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        if isSecure {
+                            SecureField("sk-ant-...", text: $keyInput)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                        } else {
+                            TextField("sk-ant-...", text: $keyInput)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                        }
+                        Button {
+                            isSecure.toggle()
+                        } label: {
+                            Image(systemName: isSecure ? "eye.slash" : "eye")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } header: {
+                    Text("Anthropic API Key")
+                } footer: {
+                    Text("Your API key is stored locally on this device and never shared. Get a key at console.anthropic.com.")
+                }
+
+                Section {
+                    Button("Save API Key") {
+                        service.apiKey = keyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                        dismiss()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .disabled(keyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+
+                if service.hasAPIKey {
+                    Section {
+                        Button("Remove API Key", role: .destructive) {
+                            service.apiKey = ""
+                            keyInput = ""
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .navigationTitle(service.hasAPIKey ? "API Key Settings" : "Set Up Assistant")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if service.hasAPIKey {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+            }
+            .onAppear {
+                keyInput = service.apiKey
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Chat - Empty") {
+    ChatView()
+        .modelContainer(for: [
+            PantryItem.self, Category.self, StorageLocation.self,
+            ShoppingListItem.self, Recipe.self, RecipeIngredient.self,
+            RecipeInstruction.self, RecipeCategory.self, RecipeTag.self,
+            RecipeCookingNote.self, RecipeCollection.self,
+            Receipt.self, ReceiptItem.self, BarcodeMapping.self
+        ], inMemory: true)
+}
+
+#Preview("Loading Bubble") {
+    VStack {
+        LoadingBubbleView(activity: "Checking your pantry…")
+        LoadingBubbleView(activity: nil)
+    }
+    .padding()
+}

--- a/pantry/ViewsMainTabView.swift
+++ b/pantry/ViewsMainTabView.swift
@@ -43,16 +43,28 @@ struct MainTabView: View {
                 }
                 .tag(4)
 
+            ChatView()
+                .tabItem {
+                    Label("Assistant", systemImage: "sparkles")
+                }
+                .tag(5)
+
             SettingsView()
                 .tabItem {
                     Label("Settings", systemImage: "gear")
                 }
-                .tag(5)
+                .tag(6)
         }
     }
 }
 
 #Preview {
     MainTabView()
-        .modelContainer(for: [PantryItem.self, Category.self, StorageLocation.self], inMemory: true)
+        .modelContainer(for: [
+            PantryItem.self, Category.self, StorageLocation.self,
+            ShoppingListItem.self, Recipe.self, RecipeIngredient.self,
+            RecipeInstruction.self, RecipeCategory.self, RecipeTag.self,
+            RecipeCookingNote.self, RecipeCollection.self,
+            Receipt.self, ReceiptItem.self, BarcodeMapping.self
+        ], inMemory: true)
 }

--- a/pantryTests/ServicesLLMServiceTests.swift
+++ b/pantryTests/ServicesLLMServiceTests.swift
@@ -1,0 +1,169 @@
+//
+//  ServicesLLMServiceTests.swift
+//  pantryTests
+//
+
+import Testing
+import Foundation
+@testable import pantry
+
+// MARK: - LLMToolFormatter Tests
+
+struct LLMToolFormatterTests {
+
+    // MARK: - pantryItemsJSON
+
+    @Test func pantryItemsJSON_handlesEmptyArray() {
+        let json = LLMToolFormatter.pantryItemsJSON([])
+        #expect(json == "[]")
+    }
+
+    @Test func pantryItemsJSON_containsItemName() {
+        let item = PantryItem(name: "Test Apple", quantity: 3, unit: "count")
+        let json = LLMToolFormatter.pantryItemsJSON([item])
+        #expect(json.contains("Test Apple"))
+    }
+
+    @Test func pantryItemsJSON_containsQuantityAndUnit() {
+        let item = PantryItem(name: "Sugar", quantity: 2.5, unit: "kg")
+        let json = LLMToolFormatter.pantryItemsJSON([item])
+        #expect(json.contains("kg"))
+    }
+
+    @Test func pantryItemsJSON_includesExpirationFlag() {
+        let pastDate = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let item = PantryItem(name: "Milk", quantity: 1, unit: "gallon", expirationDate: pastDate)
+        let json = LLMToolFormatter.pantryItemsJSON([item])
+        #expect(json.contains("is_expired"))
+    }
+
+    @Test func pantryItemsJSON_includesBrandWhenPresent() {
+        let item = PantryItem(name: "Cheese", quantity: 1, unit: "lb", brand: "Tillamook")
+        let json = LLMToolFormatter.pantryItemsJSON([item])
+        #expect(json.contains("Tillamook"))
+    }
+
+    @Test func pantryItemsJSON_handlesMultipleItems() {
+        let items = [
+            PantryItem(name: "Eggs", quantity: 12, unit: "count"),
+            PantryItem(name: "Butter", quantity: 1, unit: "lb")
+        ]
+        let json = LLMToolFormatter.pantryItemsJSON(items)
+        #expect(json.contains("Eggs"))
+        #expect(json.contains("Butter"))
+    }
+
+    // MARK: - recipesJSON
+
+    @Test func recipesJSON_handlesEmptyArray() {
+        let json = LLMToolFormatter.recipesJSON([])
+        #expect(json == "[]")
+    }
+
+    @Test func recipesJSON_containsRecipeName() {
+        let recipe = Recipe(name: "Test Pasta", prepTime: 10, cookTime: 20, servings: 2)
+        let json = LLMToolFormatter.recipesJSON([recipe])
+        #expect(json.contains("Test Pasta"))
+    }
+
+    @Test func recipesJSON_containsDifficultyAndServings() {
+        let recipe = Recipe(name: "Easy Salad", prepTime: 5, cookTime: 0, servings: 4, difficulty: .easy)
+        let json = LLMToolFormatter.recipesJSON([recipe])
+        #expect(json.contains("Easy"))
+    }
+
+    @Test func recipesJSON_includesFavoriteFlag() {
+        let recipe = Recipe(name: "Fav Recipe", prepTime: 10, cookTime: 30, servings: 2, isFavorite: true)
+        let json = LLMToolFormatter.recipesJSON([recipe])
+        #expect(json.contains("is_favorite"))
+    }
+
+    // MARK: - recipeDetailJSON
+
+    @Test func recipeDetailJSON_containsNameAndTimes() {
+        let recipe = Recipe(name: "Spaghetti", prepTime: 10, cookTime: 20, servings: 4)
+        let json = LLMToolFormatter.recipeDetailJSON(recipe)
+        #expect(json.contains("Spaghetti"))
+        #expect(json.contains("prep_time_minutes"))
+        #expect(json.contains("cook_time_minutes"))
+    }
+
+    @Test func recipeDetailJSON_containsIngredientsList() {
+        let recipe = Recipe(name: "Test Recipe", prepTime: 5, cookTime: 10, servings: 2)
+        let json = LLMToolFormatter.recipeDetailJSON(recipe)
+        #expect(json.contains("ingredients"))
+        #expect(json.contains("instructions"))
+    }
+
+    // MARK: - shoppingItemsJSON
+
+    @Test func shoppingItemsJSON_handlesEmptyArray() {
+        let json = LLMToolFormatter.shoppingItemsJSON([])
+        #expect(json == "[]")
+    }
+
+    @Test func shoppingItemsJSON_containsItemName() {
+        let item = ShoppingListItem(name: "Butter", quantity: 1, unit: "lb")
+        let json = LLMToolFormatter.shoppingItemsJSON([item])
+        #expect(json.contains("Butter"))
+    }
+
+    @Test func shoppingItemsJSON_showsCheckedState_whenChecked() {
+        let item = ShoppingListItem(name: "Milk", quantity: 1, unit: "gallon", isChecked: true)
+        let json = LLMToolFormatter.shoppingItemsJSON([item])
+        #expect(json.contains("is_checked"))
+        #expect(json.contains("true"))
+    }
+
+    @Test func shoppingItemsJSON_showsCheckedState_whenUnchecked() {
+        let item = ShoppingListItem(name: "Eggs", quantity: 12, unit: "count", isChecked: false)
+        let json = LLMToolFormatter.shoppingItemsJSON([item])
+        #expect(json.contains("is_checked"))
+        #expect(json.contains("false"))
+    }
+
+    @Test func shoppingItemsJSON_includesPriority() {
+        let item = ShoppingListItem(name: "Coffee", quantity: 1, unit: "bag", priority: 2)
+        let json = LLMToolFormatter.shoppingItemsJSON([item])
+        #expect(json.contains("priority"))
+    }
+
+    // MARK: - expiringItemsJSON
+
+    @Test func expiringItemsJSON_returnsOnlyExpiringItems() {
+        let expiringItem = PantryItem(
+            name: "Cheese",
+            quantity: 0.5,
+            unit: "lb",
+            expirationDate: Calendar.current.date(byAdding: .day, value: 2, to: Date())
+        )
+        let freshItem = PantryItem(
+            name: "Pasta",
+            quantity: 1,
+            unit: "box",
+            expirationDate: Calendar.current.date(byAdding: .month, value: 6, to: Date())
+        )
+        let json = LLMToolFormatter.expiringItemsJSON([expiringItem, freshItem])
+        #expect(json.contains("Cheese"))
+        #expect(!json.contains("Pasta"))
+    }
+
+    @Test func expiringItemsJSON_includesExpiredItems() {
+        let expiredItem = PantryItem(
+            name: "Old Milk",
+            quantity: 1,
+            unit: "gallon",
+            expirationDate: Calendar.current.date(byAdding: .day, value: -3, to: Date())
+        )
+        let json = LLMToolFormatter.expiringItemsJSON([expiredItem])
+        #expect(json.contains("Old Milk"))
+        #expect(json.contains("is_expired"))
+    }
+
+    @Test func expiringItemsJSON_handlesItemWithNoExpiration() {
+        let item = PantryItem(name: "Rice", quantity: 5, unit: "lb")
+        // No expiration date — should not appear in expiring items
+        let json = LLMToolFormatter.expiringItemsJSON([item])
+        #expect(json == "[]" || !json.contains("Rice"))
+    }
+}


### PR DESCRIPTION
Introduces an AI-powered chat tab (Pantry Assistant) backed by the Anthropic Claude API. The assistant can take real actions across the app via tool use — no third-party packages required; all network calls use URLSession.

New files:
- ServicesLLMService.swift — LLMService (@Observable, @MainActor) manages conversation history and runs the agentic tool-use loop. LLMToolFormatter provides pure static serialisation helpers (testable without SwiftData). Thirteen tools are defined: get/add/update/remove pantry items, get/detail/ create recipes, get/add/check/clear shopping list items, get expiring items, and suggest recipes using RecipePantryService.
- ViewsChatChatView.swift — SwiftUI chat interface with chat bubbles, an animated loading indicator that shows tool activity labels, a multi-line input bar, a welcome screen with suggestion chips, and an API key setup sheet (key stored in UserDefaults, never transmitted to any server other than api.anthropic.com).
- pantryTests/ServicesLLMServiceTests.swift — TDD tests for LLMToolFormatter covering pantry items, recipes, shopping items, and expiring-items serialisation (written before implementation per FIRST principles).

Modified:
- ViewsMainTabView.swift — adds the Assistant tab (sparkles icon, tag 5); Settings shifts to tag 6.

https://claude.ai/code/session_01S2J1L2Zawvkb4KJcyrxdWp