### PR TITLE
[codex] Fix assistant interactivity and shared chat session

### DIFF
--- a/pantry/ServicesAssistantSessionStore.swift
+++ b/pantry/ServicesAssistantSessionStore.swift
@@ -1,0 +1,29 @@
+//
+//  ServicesAssistantSessionStore.swift
+//  pantry
+//
+
+import Foundation
+import SwiftData
+
+@Observable
+@MainActor
+final class AssistantSessionStore {
+    let service: LLMService
+    var draftMessage = ""
+
+    init(service: LLMService? = nil) {
+        self.service = service ?? LLMService()
+    }
+
+    func sendDraft(context: ModelContext) async {
+        let trimmed = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        draftMessage = ""
+        await service.sendMessage(trimmed, context: context)
+    }
+
+    func clearConversation() {
+        service.clearConversation()
+    }
+}

--- a/pantry/ServicesLLMService.swift
+++ b/pantry/ServicesLLMService.swift
@@ -207,11 +207,17 @@ enum LLMError: LocalizedError {
 @Observable
 @MainActor
 final class LLMService {
+    enum ModelProfile: Equatable {
+        case balanced
+        case quality
+        case fast
+    }
 
     // MARK: Public state
 
     var chatMessages: [ChatMessage] = []
     var isLoading = false
+    let modelProfile: ModelProfile
 
     var apiKey: String {
         get { keychainService.loadAPIKey() }
@@ -223,9 +229,33 @@ final class LLMService {
     // MARK: Private state
 
     private var conversationHistory: [[String: Any]] = []
-    private let modelID = "claude-opus-4-6"
-    private let maxTokens = 4096
     private let keychainService = KeychainService()
+
+    var modelID: String {
+        switch modelProfile {
+        case .balanced:
+            return "claude-sonnet-4-5"
+        case .quality:
+            return "claude-opus-4-6"
+        case .fast:
+            return "claude-haiku-4-5"
+        }
+    }
+
+    private var maxTokens: Int {
+        switch modelProfile {
+        case .balanced:
+            return 2048
+        case .quality:
+            return 4096
+        case .fast:
+            return 1024
+        }
+    }
+
+    init(modelProfile: ModelProfile = .balanced) {
+        self.modelProfile = modelProfile
+    }
 
     // MARK: - Public API
 
@@ -252,7 +282,10 @@ final class LLMService {
         } catch {
             let message = (error as? LLMError)?.errorDescription
                 ?? "Error: \(error.localizedDescription)"
-            chatMessages[loadingIndex] = ChatMessage(role: .assistant, content: message)
+            chatMessages[loadingIndex] = ChatMessage(
+                role: .assistant,
+                content: Self.normalizeAssistantResponse(message)
+            )
         }
 
         isLoading = false
@@ -278,7 +311,10 @@ final class LLMService {
                     .filter { ($0["type"] as? String) == "text" }
                     .compactMap { $0["text"] as? String }
                     .joined()
-                chatMessages[loadingIndex] = ChatMessage(role: .assistant, content: text)
+                chatMessages[loadingIndex] = ChatMessage(
+                    role: .assistant,
+                    content: Self.normalizeAssistantResponse(text)
+                )
                 continueLoop = false
 
             case "tool_use":
@@ -705,7 +741,7 @@ final class LLMService {
 
     // MARK: - System Prompt
 
-    private var systemPrompt: String {
+    var systemPrompt: String {
         let date = DateFormatter.localizedString(from: Date(), dateStyle: .long, timeStyle: .none)
         return """
         You are a helpful kitchen and pantry assistant integrated into the Pantry iOS app. \
@@ -728,8 +764,38 @@ final class LLMService {
           then be creative and helpful in your recommendations.
         - For recipe creation, include enough detail so the user can actually cook the dish.
         - Be conversational and friendly, like a knowledgeable sous-chef.
+        - Return plain text only.
+        - Do not use Markdown, code blocks, tables, or heading syntax.
         - Today's date is \(date).
         """
+    }
+
+    static func normalizeAssistantResponse(_ text: String) -> String {
+        let lines = text.components(separatedBy: .newlines)
+        let cleaned = lines.map { line in
+            var value = line.trimmingCharacters(in: .whitespaces)
+            if value.hasPrefix("```") {
+                return ""
+            }
+            if value.hasPrefix("### ") {
+                value = String(value.dropFirst(4))
+            } else if value.hasPrefix("## ") {
+                value = String(value.dropFirst(3))
+            } else if value.hasPrefix("# ") {
+                value = String(value.dropFirst(2))
+            }
+            if value.hasPrefix("- ") {
+                value = String(value.dropFirst(2))
+            } else if value.hasPrefix("* ") {
+                value = String(value.dropFirst(2))
+            }
+            return value
+        }
+
+        return cleaned
+            .joined(separator: "\n")
+            .replacingOccurrences(of: "\n\n\n", with: "\n\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Tool Definitions

--- a/pantry/ViewsChatChatView.swift
+++ b/pantry/ViewsChatChatView.swift
@@ -17,24 +17,19 @@ struct ChatView: View {
     @Query(sort: \Recipe.name) private var recipes: [Recipe]
     @Query(sort: \ShoppingListItem.addedDate) private var shoppingItems: [ShoppingListItem]
 
-    @State private var service = LLMService()
-    @State private var inputText = ""
+    @Bindable var session: AssistantSessionStore
     @State private var showAPIKeySheet = false
     @FocusState private var isInputFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
-            if service.hasAPIKey {
-                chatInterface
-            } else {
-                APIKeySetupView(service: service)
-            }
+            chatInterface
         }
         .navigationTitle("Pantry Assistant")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbarItems }
         .sheet(isPresented: $showAPIKeySheet) {
-            APIKeySetupView(service: service)
+            APIKeySetupView(service: session.service)
                 .presentationDetents([.medium])
         }
     }
@@ -45,12 +40,17 @@ struct ChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {
-                    if service.chatMessages.isEmpty {
+                    if !session.service.hasAPIKey {
+                        MissingAPIKeyBanner {
+                            showAPIKeySheet = true
+                        }
+                    }
+                    if session.service.chatMessages.isEmpty {
                         WelcomeMessageView(onSelect: sendSuggestion)
                             .frame(maxWidth: .infinity)
                             .padding(.top, 48)
                     }
-                    ForEach(service.chatMessages) { message in
+                    ForEach(session.service.chatMessages) { message in
                         ChatBubbleView(message: message)
                             .id(message.id)
                     }
@@ -65,22 +65,23 @@ struct ChatView: View {
                 VStack(spacing: 0) {
                     Divider()
                     ChatInputBar(
-                        text: $inputText,
-                        isLoading: service.isLoading,
+                        text: $session.draftMessage,
+                        isLoading: session.service.isLoading,
                         isFocused: _isInputFocused,
                         onSend: sendMessage
                     )
                     .padding(.horizontal)
-                    .padding(.vertical, 8)
+                    .padding(.top, 8)
+                    .padding(.bottom, 70)
                     .background(.bar)
                 }
             }
-            .onChange(of: service.chatMessages.count) {
+            .onChange(of: session.service.chatMessages.count) {
                 withAnimation(.easeOut(duration: 0.25)) {
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
-            .onChange(of: service.chatMessages.last?.content) {
+            .onChange(of: session.service.chatMessages.last?.content) {
                 withAnimation(.easeOut(duration: 0.15)) {
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
@@ -93,28 +94,22 @@ struct ChatView: View {
     @ToolbarContentBuilder
     private var toolbarItems: some ToolbarContent {
         ToolbarItem(placement: .navigationBarTrailing) {
-            if service.hasAPIKey {
-                Menu {
-                    NavigationLink {
-                        MealPlanListView()
-                    } label: {
-                        Label("Open Meal Plans", systemImage: "calendar.badge.clock")
-                    }
-                    Divider()
-                    Button {
-                        showAPIKeySheet = true
-                    } label: {
-                        Label("API Key Settings", systemImage: "key")
-                    }
+            Menu {
+                Button {
+                    showAPIKeySheet = true
+                } label: {
+                    Label("API Key Settings", systemImage: "key")
+                }
+                if session.service.hasAPIKey {
                     Divider()
                     Button(role: .destructive) {
-                        service.clearConversation()
+                        session.clearConversation()
                     } label: {
                         Label("Clear Chat", systemImage: "trash")
                     }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
                 }
+            } label: {
+                Image(systemName: "ellipsis.circle")
             }
         }
     }
@@ -122,18 +117,41 @@ struct ChatView: View {
     // MARK: - Send Message
 
     private func sendMessage() {
-        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = session.draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
-        inputText = ""
+        guard session.service.hasAPIKey else {
+            showAPIKeySheet = true
+            return
+        }
         isInputFocused = false
         Task {
-            await service.sendMessage(text, context: modelContext)
+            await session.sendDraft(context: modelContext)
         }
     }
 
     private func sendSuggestion(_ text: String) {
-        inputText = text
+        session.draftMessage = text
         sendMessage()
+    }
+}
+
+private struct MissingAPIKeyBanner: View {
+    let onSetupTap: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Assistant setup required")
+                .font(.headline)
+            Text("Add your Anthropic API key to start chatting.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Button("Set Up API Key", action: onSetupTap)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 
@@ -396,7 +414,7 @@ struct APIKeySetupView: View {
 // MARK: - Preview
 
 #Preview("Chat - Empty") {
-    ChatView()
+    ChatView(session: AssistantSessionStore())
         .modelContainer(for: [
             PantryItem.self, Category.self, StorageLocation.self,
             ShoppingListItem.self, Recipe.self, RecipeIngredient.self,

--- a/pantry/ViewsDashboardDashboardView.swift
+++ b/pantry/ViewsDashboardDashboardView.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 struct DashboardView: View {
     @Environment(\.modelContext) private var modelContext
+    @Bindable var assistantSession: AssistantSessionStore
 
     @Query private var pantryItems: [PantryItem]
     @Query(sort: \ShoppingListItem.priority, order: .reverse) private var shoppingItems: [ShoppingListItem]
@@ -165,7 +166,11 @@ struct DashboardView: View {
                         }
                     }
 
-                    DashboardAISection(pantryItems: activePantryItems, recipes: recipes)
+                    DashboardAISection(
+                        pantryItems: activePantryItems,
+                        recipes: recipes,
+                        assistantSession: assistantSession
+                    )
                         .padding(.horizontal)
 
                     if let plan = activeMealPlan {
@@ -192,7 +197,7 @@ struct DashboardView: View {
                         .padding(.horizontal)
                     }
 
-                    DashboardQuickActions()
+                    DashboardQuickActions(assistantSession: assistantSession)
                         .padding(.horizontal)
 
                     if let actionStatusMessage {
@@ -223,7 +228,7 @@ struct DashboardView: View {
                 .padding(.trailing, 16)
             }
             .sheet(isPresented: $showMoreMenu) {
-                MoreMenuView()
+                MoreMenuView(assistantSession: assistantSession)
             }
             .confirmationDialog(
                 pendingConfirmation?.title ?? "Approve Copilot Action",
@@ -540,11 +545,7 @@ struct DashboardAISection: View {
 
     let pantryItems: [PantryItem]
     let recipes: [Recipe]
-
-    @State private var service = LLMService()
-    @State private var query = ""
-    @State private var response: String? = nil
-    @State private var isLoading = false
+    @Bindable var assistantSession: AssistantSessionStore
 
     private let promptChips = [
         "What can I make tonight?",
@@ -565,7 +566,7 @@ struct DashboardAISection: View {
                 Text("Copilot Console")
                     .font(.headline)
                 Spacer()
-                NavigationLink(destination: ChatView()) {
+                NavigationLink(destination: ChatView(session: assistantSession)) {
                     Label("Open Assistant", systemImage: "arrow.right.circle")
                         .font(.caption)
                         .foregroundStyle(.indigo)
@@ -574,7 +575,7 @@ struct DashboardAISection: View {
 
             LazyVGrid(columns: chipColumns, alignment: .leading, spacing: 8) {
                 ForEach(promptChips, id: \.self) { chip in
-                    Button { query = chip } label: {
+                    Button { assistantSession.draftMessage = chip } label: {
                         Text(chip)
                             .font(.caption)
                             .lineLimit(1)
@@ -589,7 +590,7 @@ struct DashboardAISection: View {
             }
 
             HStack(spacing: 10) {
-                TextField("Ask anything about your pantry…", text: $query, axis: .vertical)
+                TextField("Ask anything about your pantry…", text: $assistantSession.draftMessage, axis: .vertical)
                     .lineLimit(1...3)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
@@ -600,28 +601,37 @@ struct DashboardAISection: View {
                     sendQuery()
                 } label: {
                     Group {
-                        if isLoading {
+                        if assistantSession.service.isLoading {
                             ProgressView().tint(.white)
                         } else {
                             Image(systemName: "arrow.up").fontWeight(.bold)
                         }
                     }
                     .frame(width: 36, height: 36)
-                    .background(query.isEmpty ? Color.secondary : Color.indigo)
+                    .background(
+                        assistantSession.draftMessage
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                            .isEmpty ? Color.secondary : Color.indigo
+                    )
                     .foregroundStyle(.white)
                     .clipShape(Circle())
                 }
-                .disabled(query.isEmpty || isLoading)
+                .disabled(
+                    assistantSession.draftMessage
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty || assistantSession.service.isLoading
+                )
             }
 
-            if let response {
+            if !assistantSession.service.chatMessages.isEmpty {
                 ScrollView(.vertical, showsIndicators: true) {
-                    Text(response)
-                        .font(.subheadline)
-                        .foregroundStyle(.primary)
-                        .textSelection(.enabled)
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(assistantSession.service.chatMessages.suffix(6)) { message in
+                            ChatBubbleView(message: message)
+                        }
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .frame(maxHeight: 220)
                 .background(Color.indigo.opacity(0.08))
@@ -641,29 +651,15 @@ struct DashboardAISection: View {
             RoundedRectangle(cornerRadius: 14)
                 .stroke(Color.indigo.opacity(0.2), lineWidth: 1)
         )
-        .animation(.easeOut(duration: 0.2), value: response)
+        .animation(.easeOut(duration: 0.2), value: assistantSession.service.chatMessages.count)
     }
 
     private func sendQuery() {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = assistantSession.draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        isLoading = true
-        response = nil
-
         Task {
-            service.clearConversation()
-            let dashboardPrompt = """
-            \(trimmed)
-
-            Keep your answer concise (max 120 words) and practical.
-            """
-
-            await service.sendMessage(dashboardPrompt, context: modelContext)
-            response = service.chatMessages.last(where: { $0.role == .assistant })?.content
-                ?? "No response from assistant."
-            query = ""
-            isLoading = false
+            await assistantSession.sendDraft(context: modelContext)
         }
     }
 }
@@ -731,13 +727,15 @@ private struct TopRecipeMatchCard: View {
 }
 
 private struct DashboardQuickActions: View {
+    @Bindable var assistantSession: AssistantSessionStore
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Quick Actions")
                 .font(.headline)
 
             HStack(spacing: 10) {
-                NavigationLink(destination: ChatView()) {
+                NavigationLink(destination: ChatView(session: assistantSession)) {
                     QuickActionTile(icon: "sparkles", label: "Open\nAssistant", color: .indigo)
                 }
                 NavigationLink(destination: MealPlanListView()) {
@@ -787,6 +785,6 @@ private struct QuickActionTile: View {
 
     SampleDataService.loadSampleData(into: container.mainContext)
 
-    return DashboardView()
+    return DashboardView(assistantSession: AssistantSessionStore())
         .modelContainer(container)
 }

--- a/pantry/ViewsMainTabView.swift
+++ b/pantry/ViewsMainTabView.swift
@@ -13,16 +13,17 @@ struct MainTabView: View {
     @State private var showAddItem = false
     @State private var showAddShoppingItem = false
     @State private var showMoreMenu = false
+    @State private var assistantSession = AssistantSessionStore()
 
     var body: some View {
         Group {
             switch selectedTab {
             case 0:
                 NavigationStack {
-                    ChatView()
+                    ChatView(session: assistantSession)
                 }
             case 1:
-                DashboardView()
+                DashboardView(assistantSession: assistantSession)
             case 2:
                 PantryListView(showAddItem: $showAddItem)
                     .withGearIcon(showMoreMenu: $showMoreMenu)
@@ -44,7 +45,7 @@ struct MainTabView: View {
         }
         .ignoresSafeArea(.keyboard)
         .sheet(isPresented: $showMoreMenu) {
-            MoreMenuView()
+            MoreMenuView(assistantSession: assistantSession)
         }
     }
 }
@@ -122,6 +123,7 @@ extension View {
 struct MoreMenuView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var selectedMenuItem: MenuItem?
+    let assistantSession: AssistantSessionStore
 
     enum MenuItem: String, CaseIterable, Identifiable {
         case dashboard = "Dashboard"
@@ -190,7 +192,7 @@ struct MoreMenuView: View {
             .navigationDestination(item: $selectedMenuItem) { item in
                 switch item {
                 case .dashboard:
-                    DashboardView()
+                    DashboardView(assistantSession: assistantSession)
                 case .receipts:
                     ReceiptsListView(showingSourcePicker: .constant(false))
                 case .mealPlan:
@@ -198,7 +200,7 @@ struct MoreMenuView: View {
                 case .recipes:
                     RecipesListView(showAddRecipe: .constant(false))
                 case .assistant:
-                    ChatView()
+                    ChatView(session: assistantSession)
                 case .insights:
                     InsightsView()
                 case .settings:

--- a/pantryTests/ServicesAssistantSessionStoreTests.swift
+++ b/pantryTests/ServicesAssistantSessionStoreTests.swift
@@ -1,0 +1,37 @@
+//
+//  ServicesAssistantSessionStoreTests.swift
+//  pantryTests
+//
+
+import Testing
+@testable import pantry
+
+@MainActor
+struct AssistantSessionStoreTests {
+
+    @Test func clearConversation_isOnlyPathThatEmptiesSharedThread() {
+        let store = AssistantSessionStore()
+        store.service.chatMessages = [
+            ChatMessage(role: .user, content: "hello"),
+            ChatMessage(role: .assistant, content: "hi")
+        ]
+
+        #expect(store.service.chatMessages.count == 2)
+
+        store.clearConversation()
+
+        #expect(store.service.chatMessages.isEmpty)
+    }
+
+    @Test func sharedStore_referenceRetainsMessagesAcrossConsumers() {
+        let store = AssistantSessionStore()
+        store.service.chatMessages = [ChatMessage(role: .user, content: "almonds")]
+
+        let firstConsumer = store
+        let secondConsumer = store
+
+        #expect(firstConsumer.service.chatMessages.count == 1)
+        #expect(secondConsumer.service.chatMessages.count == 1)
+    }
+}
+

--- a/pantryTests/ServicesLLMServiceTests.swift
+++ b/pantryTests/ServicesLLMServiceTests.swift
@@ -167,3 +167,36 @@ struct LLMToolFormatterTests {
         #expect(json == "[]" || !json.contains("Rice"))
     }
 }
+
+// MARK: - LLM Service Configuration Tests
+
+@MainActor
+struct LLMServiceConfigurationTests {
+
+    @Test func init_defaultsToBalancedProfile() {
+        let service = LLMService()
+        #expect(service.modelProfile == .balanced)
+        #expect(service.modelID == "claude-sonnet-4-5")
+    }
+
+    @Test func normalizeAssistantResponse_stripsCommonMarkdownArtifacts() {
+        let input = """
+        ## Dinner ideas
+        - Use almonds
+        - Make pesto
+        ```swift
+        print("x")
+        ```
+        """
+        let normalized = LLMService.normalizeAssistantResponse(input)
+        #expect(!normalized.contains("##"))
+        #expect(!normalized.contains("```"))
+        #expect(normalized.contains("Dinner ideas"))
+    }
+
+    @Test func systemPrompt_enforcesPlainTextResponses() {
+        let service = LLMService()
+        #expect(service.systemPrompt.contains("Return plain text only"))
+        #expect(service.systemPrompt.contains("Do not use Markdown"))
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes assistant interactivity regressions introduced during the AI-first navigation pivot.

Users reported four concrete issues affecting the Pantry Assistant experience:
- no visible chat input bar in Assistant (issue #6)
- slow responses with markdown-style output despite plain-text UI expectations
- chat history being lost when navigating back
- unnecessary "Open Meal Plans" action in the Assistant menu

## User Impact
Before this fix, users could end up in the Assistant without a usable message composer, and conversation continuity broke across navigation flows. The Home copilot surface behaved like a one-shot query box instead of a persistent assistant thread, and response formatting could show markdown artifacts that the UI does not render.

After this fix, users can always see and use an input bar, keep one shared thread across Home and Assistant, and receive plain-text-oriented responses. The extra menu action has been removed to reduce clutter.

## Root Cause
The prior implementation held assistant state inside view-local `@State` service instances (`ChatView` and Home dashboard section), which are recreated as navigation stacks/sheets are rebuilt. That caused thread loss and inconsistent composer behavior. In parallel, the LLM service used a quality-first model and did not enforce/normalize plain-text output for markdown-sensitive rendering contexts.

## What Changed
- Added `AssistantSessionStore` as a shared, observable session boundary for assistant state:
  - shared `LLMService`
  - shared draft message
  - central send/clear methods
- Rewired `MainTabView`, `MoreMenuView`, `DashboardView`, and `ChatView` to use the same `AssistantSessionStore` instance.
- Converted Home's copilot console from one-shot response state to shared threaded history display + shared input drafting.
- Updated `LLMService`:
  - added model profiles (`balanced`, `quality`, `fast`)
  - defaulted to `balanced` profile for better speed/quality tradeoff
  - added plain-text-only guidance in system prompt
  - added response normalization to strip common markdown artifacts before display
- Updated `ChatView` behavior:
  - menu now keeps API key settings + clear chat only
  - removed "Open Meal Plans" action
  - always shows chat interface and bottom input bar
  - if API key is missing, sending opens setup and shows an inline setup banner

## Validation
- Ran targeted tests:
  - `xcodebuild test -project pantry.xcodeproj -scheme pantry -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:pantryTests/ServicesLLMServiceTests -only-testing:pantryTests/ServicesAssistantSessionStoreTests`
  - Result: **TEST SUCCEEDED**
- Ran app build:
  - `xcodebuild build -project pantry.xcodeproj -scheme pantry -destination 'platform=iOS Simulator,name=iPhone 17'`
  - Result: **BUILD SUCCEEDED**
- Launched app in simulator:
  - `xcrun simctl launch booted foundation.pantry`

## Notes
- Closes #6.
