### PR TITLE
[codex] implement pantry search ui and tests

### DIFF
--- a/pantry/ServicesPantrySearchService.swift
+++ b/pantry/ServicesPantrySearchService.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct PantrySearchService {
+    static func filter(items: [PantryItem], query: String) -> [PantryItem] {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedQuery.isEmpty else {
+            return items
+        }
+
+        return items.filter { item in
+            searchableFields(for: item).contains { field in
+                field.localizedCaseInsensitiveContains(normalizedQuery)
+            }
+        }
+    }
+
+    private static func searchableFields(for item: PantryItem) -> [String] {
+        [
+            item.name,
+            item.brand,
+            item.unit,
+            item.notes,
+            item.itemDescription,
+            item.barcode,
+            item.category?.name,
+            item.location?.name
+        ]
+        .compactMap { $0 }
+    }
+}

--- a/pantry/ViewsPantryPantryListView.swift
+++ b/pantry/ViewsPantryPantryListView.swift
@@ -21,6 +21,7 @@ struct PantryListView: View {
     @State private var selectedLocation: StorageLocation?
     @State private var sortOrder: SortOrder = .name
     @State private var showingFilters = false
+    @State private var hasAppliedUITestSearchSeed = false
     /// Set to a non-nil item when a decrement would bring quantity to zero;
     /// triggers the "Remove from pantry?" confirmation dialog.
     @State private var itemPendingDelete: PantryItem?
@@ -36,12 +37,7 @@ struct PantryListView: View {
         var result = items.filter { !$0.isArchived }
         
         // Search filter
-        if !searchText.isEmpty {
-            result = result.filter { item in
-                item.name.localizedCaseInsensitiveContains(searchText) ||
-                item.brand?.localizedCaseInsensitiveContains(searchText) == true
-            }
-        }
+        result = PantrySearchService.filter(items: result, query: searchText)
         
         // Category filter
         if let selectedCategory {
@@ -104,13 +100,42 @@ struct PantryListView: View {
         .background(Color(.secondarySystemBackground))
     }
 
+    // MARK: - Search Bar
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+
+            TextField("Search items", text: $searchText)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .accessibilityLabel("pantry.searchField")
+                .accessibilityIdentifier("pantry.searchField")
+
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Clear search")
+                .accessibilityIdentifier("pantry.clearSearchButton")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color(.secondarySystemBackground))
+    }
+
     var body: some View {
         NavigationStack {
             Group {
                 // Item list
                 if filteredItems.isEmpty {
                     ContentUnavailableView(
-                        "No Items",
+                        searchText.isEmpty ? "No Items" : "No Matches",
                         systemImage: "cabinet",
                         description: Text(searchText.isEmpty ? "Add your first pantry item to get started" : "No items match your search")
                     )
@@ -153,13 +178,15 @@ struct PantryListView: View {
                         }
                     }
                     .listStyle(.plain)
-                    .searchable(text: $searchText, prompt: "Search items")
                 }
             }
             // Pin the summary bar above the scrollable content without wrapping
             // the List in a VStack (which breaks scroll gesture routing in iOS 26).
             .safeAreaInset(edge: .top, spacing: 0) {
                 summaryBar
+            }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                searchBar
             }
             .navigationTitle("Pantry")
             .toolbar {
@@ -224,6 +251,7 @@ struct PantryListView: View {
             }
             .onAppear {
                 initializeDefaultData()
+                applyUITestSearchSeedIfNeeded()
             }
         }
     }
@@ -291,6 +319,20 @@ struct PantryListView: View {
         }
 
         try? modelContext.save()
+    }
+
+    private func applyUITestSearchSeedIfNeeded() {
+        guard !hasAppliedUITestSearchSeed else { return }
+        hasAppliedUITestSearchSeed = true
+        guard searchText.isEmpty else { return }
+
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let flagIndex = arguments.firstIndex(of: "-UITestPantrySearchQuery"),
+              arguments.indices.contains(flagIndex + 1) else {
+            return
+        }
+
+        searchText = arguments[flagIndex + 1]
     }
 }
 

--- a/pantryTests/ServicesPantrySearchServiceTests.swift
+++ b/pantryTests/ServicesPantrySearchServiceTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import pantry
+
+struct PantrySearchServiceTests {
+
+    @Test func filter_returnsAllItemsWhenQueryIsEmpty() {
+        let items = [
+            PantryItem(name: "Whole Milk", quantity: 1, unit: "gallon"),
+            PantryItem(name: "Eggs", quantity: 12, unit: "count")
+        ]
+
+        let result = PantrySearchService.filter(items: items, query: "")
+
+        #expect(result.count == 2)
+    }
+
+    @Test func filter_matchesName_caseInsensitive() {
+        let milk = PantryItem(name: "Whole Milk", quantity: 1, unit: "gallon")
+        let eggs = PantryItem(name: "Eggs", quantity: 12, unit: "count")
+
+        let result = PantrySearchService.filter(items: [milk, eggs], query: "MILK")
+
+        #expect(result.count == 1)
+        #expect(result.first?.name == "Whole Milk")
+    }
+
+    @Test func filter_matchesRelevantMetadata_brandCategoryAndLocation() {
+        let dairy = Category(name: "Dairy", colorHex: "#5AC8FA", iconName: "drop")
+        let fridge = StorageLocation(name: "Fridge", iconName: "snowflake")
+
+        let yogurt = PantryItem(name: "Greek Yogurt", quantity: 1, unit: "container", brand: "Fage")
+        yogurt.category = dairy
+        yogurt.location = fridge
+
+        let oil = PantryItem(name: "Olive Oil", quantity: 1, unit: "bottle", brand: "Kirkland")
+
+        let byBrand = PantrySearchService.filter(items: [yogurt, oil], query: "fage")
+        #expect(byBrand.count == 1)
+        #expect(byBrand.first?.name == "Greek Yogurt")
+
+        let byCategory = PantrySearchService.filter(items: [yogurt, oil], query: "dairy")
+        #expect(byCategory.count == 1)
+        #expect(byCategory.first?.name == "Greek Yogurt")
+
+        let byLocation = PantrySearchService.filter(items: [yogurt, oil], query: "fridge")
+        #expect(byLocation.count == 1)
+        #expect(byLocation.first?.name == "Greek Yogurt")
+    }
+
+    @Test func filter_returnsNoItemsWhenNothingMatches() {
+        let items = [
+            PantryItem(name: "Whole Milk", quantity: 1, unit: "gallon"),
+            PantryItem(name: "Eggs", quantity: 12, unit: "count")
+        ]
+
+        let result = PantrySearchService.filter(items: items, query: "saffron")
+
+        #expect(result.isEmpty)
+    }
+}

--- a/pantryUITests/pantryUITests.swift
+++ b/pantryUITests/pantryUITests.swift
@@ -20,6 +20,7 @@
 //    TC-08  Checking off a shopping item shows the "checked" count
 //    TC-09  Tapping a pantry item navigates to its detail view
 //    TC-10  Swipe-to-delete removes a pantry item from the list
+//    TC-11  Pantry search no-match state and clear reset
 //
 
 import XCTest
@@ -349,5 +350,41 @@ final class PantryRegressionTests: XCTestCase {
         // The Pantry list should be empty again → empty state should return.
         XCTAssertTrue(app.staticTexts["No Items"].waitForExistence(timeout: 3),
                       "'No Items' empty state should reappear after deleting the only item")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TC-11  Pantry search no-match + clear reset
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// With an empty pantry, entering any search query should switch the empty
+    /// state from "No Items" to "No Matches". Clearing the query should restore
+    /// "No Items" immediately.
+    @MainActor
+    func test_TC11_pantrySearch_noMatchStateAndClearRestoresDefaultEmptyState() throws {
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments = ["-UITesting", "-UITestPantrySearchQuery", "zzzz"]
+        app.launch()
+
+        let pantryTab = app.buttons.matching(NSPredicate(format: "label == 'Pantry'")).firstMatch
+        XCTAssertTrue(pantryTab.waitForExistence(timeout: 5), "Pantry tab button should be visible")
+        pantryTab.tap()
+        XCTAssertTrue(app.navigationBars["Pantry"].waitForExistence(timeout: 5),
+                      "Expected to be on Pantry screen before running search assertions")
+
+        XCTAssertTrue(app.staticTexts["No Matches"].waitForExistence(timeout: 3),
+                      "No-match search should show explicit 'No Matches' state")
+        XCTAssertFalse(app.staticTexts["No Items"].exists,
+                       "'No Items' should not be shown while a no-match query is active")
+
+        let clearButton = app.buttons["pantry.clearSearchButton"]
+        XCTAssertTrue(clearButton.waitForExistence(timeout: 3),
+                      "Clear button should be visible when the search query is non-empty")
+        clearButton.tap()
+
+        XCTAssertFalse(app.staticTexts["No Matches"].waitForExistence(timeout: 3),
+                       "'No Matches' should disappear after clearing search")
+        XCTAssertFalse(clearButton.exists,
+                       "Clear button should disappear once the query is reset")
     }
 }


### PR DESCRIPTION
## Summary
This PR implements issue #8 by adding a real Pantry search experience with deterministic test coverage.

As pantry inventories grow, users need a fast way to find a specific item without scrolling through the full list. Before this change, search behavior was inconsistent in edge states and difficult to validate through regression tests.

## User Impact (Before vs After)
Before this fix, search behavior depended on the default SwiftUI `.searchable` placement and had weak coverage for no-match and clear/reset behavior. In practical use, this made it harder to confidently verify that users could recover from no-match states and immediately return to normal browsing.

After this fix:
- Pantry search is always available from a bottom search bar on the Pantry screen.
- Search filters results in real time with case-insensitive matching.
- Matching includes item name and relevant metadata (brand, unit, notes, description, barcode, category, location).
- No-match state is explicit (`No Matches`).
- Clearing search is explicit and immediate via a clear button.

## Root Cause
Search/filter logic was embedded directly in the view and only partially covered, which left no reusable unit-level surface for search semantics and no robust UI-level regression around no-match/clear transitions.

## Fix
I split Pantry search into a dedicated service and updated the Pantry view + tests.

### 1) New dedicated search service
- Added `PantrySearchService.filter(items:query:)`.
- Centralized search matching behavior.
- Added metadata-aware search fields for practical item discovery.

### 2) Pantry UI integration
- Wired Pantry list filtering to `PantrySearchService`.
- Added a pinned bottom search bar (instead of relying solely on list-level `.searchable`).
- Added explicit clear control for query reset.
- Added stable UI automation identifiers for search controls.
- Added a one-time UI-test query seed hook (`-UITestPantrySearchQuery`) so no-match flows are deterministic under XCTest.

### 3) Test coverage
- Added new unit tests for search semantics (`pantryTests/ServicesPantrySearchServiceTests.swift`):
  - empty query returns all items
  - case-insensitive name matching
  - metadata matching
  - no-match result
- Added new UI regression test (`TC-11`) in `pantryUITests/pantryUITests.swift`:
  - verifies no-match state
  - verifies clear behavior removes no-match state and clear affordance

## Validation
I ran focused tests for this change:

- `xcodebuild test -project pantry.xcodeproj -scheme pantry -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:pantryTests/ServicesPantrySearchServiceTests -only-testing:pantryUITests/PantryRegressionTests/test_TC11_pantrySearch_noMatchStateAndClearRestoresDefaultEmptyState`

Result: `TEST SUCCEEDED`.

## Issue Link
Closes #8
